### PR TITLE
fix(hello): read serial at fixed offset, not a content scan

### DIFF
--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -134,17 +134,56 @@ HelloInfo parseHello(Uint8List payload) {
   if (payload.length > 5) info.charging = payload[5] != 0;
   if (payload.length > 116) info.wristOn = payload[116] != 0;
 
+  // Serial is a NUL-terminated ASCII token at a FIXED offset in the body:
+  // payload[16] (= inner[19]), immediately followed by the 64-char firmware
+  // commit hash. Verified on real captures (serial "4C2248092" @16 across builds).
+  // We read it at the offset rather than "first printable run from offset 6" —
+  // the bytes [0:16] are a volatile binary header (battery, counters, clock) that
+  // on some firmware contain printable bytes and made the scan latch onto junk
+  // (the "?*" the user saw). The serial is NOT derivable from the advertised name
+  // either: that is user-renamable (e.g. "Abdul's WHOOP").
+  const serialOffset = 16;
+  final s = _cstrAt(payload, serialOffset);
+  if (_validSerial(s)) info.serial = s;
+
+  // Commit = the long hex token. It sits right after the serial's NUL, but we
+  // locate it by content (first ≥16-char all-hex run) so a small layout shift
+  // can't drop it.
   const hexset = '0123456789abcdefABCDEF';
-  for (final r in _asciiRuns(payload, 6, 6)) {
-    if (info.serial == null && r.length >= 6 && r.length <= 13) {
-      info.serial = r;
-    } else if (info.commit == null &&
-        r.length >= 16 &&
-        r.split('').every((c) => hexset.contains(c))) {
+  for (final r in _asciiRuns(payload, serialOffset, 16)) {
+    if (r.length >= 16 && r.split('').every((c) => hexset.contains(c))) {
       info.commit = r;
+      break;
     }
   }
   return info;
+}
+
+/// Read the NUL-terminated ASCII token at [start]. Returns '' if the byte at
+/// [start] is non-printable (i.e. there is no clean token there) — so a wrong
+/// offset yields nothing rather than garbage.
+String _cstrAt(Uint8List b, int start) {
+  if (start < 0 || start >= b.length) return '';
+  final sb = StringBuffer();
+  for (int i = start; i < b.length; i++) {
+    final c = b[i];
+    if (c == 0) break; // NUL terminator
+    if (c < 0x20 || c >= 0x7F) return ''; // non-printable → not a clean token
+    sb.writeCharCode(c);
+  }
+  return sb.toString();
+}
+
+/// A WHOOP serial: 6–13 chars, alphanumeric only (no spaces/punctuation).
+bool _validSerial(String s) {
+  if (s.length < 6 || s.length > 13) return false;
+  for (final c in s.codeUnits) {
+    final isDigit = c >= 0x30 && c <= 0x39;
+    final isUpper = c >= 0x41 && c <= 0x5A;
+    final isLower = c >= 0x61 && c <= 0x7A;
+    if (!(isDigit || isUpper || isLower)) return false;
+  }
+  return true;
 }
 
 // ── EVENT (0x30) ─────────────────────────────────────────────────────────────
@@ -202,13 +241,7 @@ CmdResponse? parseCommandResponse(Uint8List inner) {
   } else if (op == Cmd.getAlarmTime && payload.length >= 5) {
     dec['alarm_epoch'] = u32(payload, 1);
   } else if (op == Cmd.getAdvertisingNameHarvard) {
-    int s = 0;
-    while (s < payload.length && payload[s] < 0x20) {
-      s++;
-    }
-    final end = payload.indexOf(0, s);
-    final nameBytes = payload.sublist(s, end < 0 ? payload.length : end);
-    dec['strap_name'] = String.fromCharCodes(nameBytes).trim();
+    dec['strap_name'] = _decodeAdvName(payload);
   } else if (op == Cmd.getClock) {
     final c = _firstPlausibleUnix(payload);
     if (c != null) dec['clock_epoch'] = c;
@@ -220,6 +253,44 @@ CmdResponse? parseCommandResponse(Uint8List inner) {
     }
   }
   return CmdResponse(op, dec);
+}
+
+/// Decode the GET_ADVERTISING_NAME response body. Verified layout (real capture):
+/// `[hdr 4B][len u8 @4][ASCII name @5 …][NUL padding]`.
+///
+/// We bound the name with the length byte and keep ONLY printable ASCII — so a
+/// name whose length byte is itself printable (≥0x20, i.e. a name ≥32 chars), a
+/// missing NUL terminator, or a stray high byte can't leak header/trailing junk
+/// into the string (the "?*" the user saw on repeat reads). Falls back to a
+/// skip-control-then-printable scan if the header isn't the expected shape.
+String _decodeAdvName(Uint8List p) {
+  // Primary: length-prefixed at the verified offset.
+  if (p.length > 5) {
+    final len = p[4];
+    if (len > 0 && len <= 20) {
+      // strap names are short (SET caps at 20)
+      final s = _printableRun(p, 5, 5 + len);
+      if (s.isNotEmpty) return s;
+    }
+  }
+  // Fallback: skip leading control bytes, then read the printable run.
+  var start = 0;
+  while (start < p.length && p[start] < 0x20) {
+    start++;
+  }
+  return _printableRun(p, start, p.length);
+}
+
+/// Build a string from [a, b) keeping only printable ASCII, stopping at the first
+/// NUL. Drops any byte ≥0x7f (which would otherwise render as "?").
+String _printableRun(Uint8List p, int a, int b) {
+  final sb = StringBuffer();
+  for (var i = a; i < b && i < p.length; i++) {
+    final c = p[i];
+    if (c == 0) break;
+    if (c >= 0x20 && c < 0x7f) sb.writeCharCode(c);
+  }
+  return sb.toString().trim();
 }
 
 // Lower floor for a "this could be a real wall-clock epoch" u32 — kept local so

--- a/test/hello_test.dart
+++ b/test/hello_test.dart
@@ -1,0 +1,82 @@
+// parse_hello serial/commit extraction — validated against REAL captured HELLO
+// responses (whoop_capture.jsonl, band serial "4C2248092"). The serial lives at a
+// fixed NUL-terminated offset (payload[16]); the old "first printable run" scan
+// latched onto the volatile binary header and surfaced "?*" junk on some firmware.
+
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // The three GET_HELLO_HARVARD response *bodies* (inner[3:]) captured live.
+  // They differ only in the volatile header bytes [0:16]; the serial is always
+  // the NUL-terminated token at offset 16.
+  const helloBodies = [
+    'a001048303000000b196e201b0020000344332323438303932003865323738326237'
+        '346634303238346333663437363138623062613234373663356431366363303533'
+        '313862373532316431353635650600000002000000100000002900000011000000'
+        '060000000000000008060000000000000011000000020000000200000000000000',
+    '0001048303000000b196e20150460000344332323438303932003865323738326237'
+        '346634303238346333663437363138623062613234373663356431366363303533'
+        '313862373532316431353635650600000002000000100000002900000011000000'
+        '060000000000000008060000000000000011000000020000000200000000000000',
+    'a00104c503000000ef77256a087d0000344332323438303932003865323738326237'
+        '346634303238346333663437363138623062613234373663356431366363303533'
+        '313862373532316431353635650600000002000000100000002900000011000000'
+        '060000000000000008060000000000000011000000020000000200000000000000',
+  ];
+
+  test('serial is read at the fixed offset on every real capture', () {
+    for (final body in helloBodies) {
+      final h = parseHello(hexToBytes(body));
+      expect(h.serial, '4C2248092',
+          reason: 'serial must be the offset-16 NUL-terminated token');
+    }
+  });
+
+  test('commit hex follows the serial', () {
+    final h = parseHello(hexToBytes(helloBodies.first));
+    expect(h.commit, isNotNull);
+    expect(h.commit!.startsWith('8e2782b7'), isTrue);
+    expect(h.commit!.length >= 16, isTrue);
+  });
+
+  test('no serial = no junk (short HELLO body returns null, never "?*")', () {
+    // The short HELLO from the parity fixtures — no serial token present.
+    const shortBody = '0291021f038d025e01000b010c020c0100000000160001510c'
+        '000000000000';
+    final h = parseHello(hexToBytes(shortBody));
+    expect(h.serial, isNull);
+  });
+
+  test('renamed-band advertised name is irrelevant to serial parsing', () {
+    // Sanity: a body whose header bytes happen to be printable must NOT be
+    // mistaken for the serial — only the offset-16 token counts.
+    final h = parseHello(hexToBytes(helloBodies[1])); // header has "PF" @12
+    expect(h.serial, '4C2248092');
+  });
+
+  group('advertising name decode', () {
+    // inner = [0x24, seq=0x65, 0x4C(opcode)] + body
+    String? name(String bodyHex) {
+      final inner = hexToBytes('24654c$bodyHex');
+      return parseCommandResponse(inner)?.decoded['strap_name'] as String?;
+    }
+
+    test('real capture body → clean name', () {
+      // [01 01 01 01][len=0e]["Abdul's WHOOP"][00 00 00]
+      expect(name('010101010e416264756c27732057484f4f50000000'),
+          "Abdul's WHOOP");
+    });
+
+    test('no NUL terminator + trailing high bytes → no junk', () {
+      // header + len=05 + "PROBE" + high bytes (no NUL). Bounded by len; high
+      // bytes dropped → must not leak "?*".
+      expect(name('0101010105' '50524f4245' 'fffe2a3f'), 'PROBE');
+    });
+
+    test('embedded high byte inside name is dropped, not rendered as "?"', () {
+      // len=06, name bytes "AB"+0xFF+"CDE" → printable-only keeps "ABCDE".
+      expect(name('0101010106' '4142ff434445' '00'), 'ABCDE');
+    });
+  });
+}

--- a/test/reassembly_stress_test.dart
+++ b/test/reassembly_stress_test.dart
@@ -1,0 +1,75 @@
+// Feed REAL captured command-response frames (HELLO + GET_ADVERTISING_NAME)
+// through the actual FrameReassembler + decodeFrame under adversarial BLE
+// chunking — whole-frame, one giant chunk, byte-by-byte, and split-across-frames.
+// Reproduces the "first read correct, second read garbled (esp. name)" report if
+// the reassembler carries state between reads.
+
+import 'dart:typed_data';
+
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+import 'package:test/test.dart';
+
+// Full on-wire frames from whoop_capture.jsonl (band serial 4C2248092, renamed
+// "Abdul's WHOOP"). Order matches capture: HELLO, HELLO, ADVNAME, HELLO.
+const frames = <String>[
+  'aa8c004a246323a001048303000000b196e201b00200003443323234383039320038653237383262373466343032383463336634373631386230626132343736633564313663633035333138623735323164313536356506000000020000001000000029000000110000000600000000000000080600000000000000110000000200000002000000000000000e3ddd35',
+  'aa8c004a2464230001048303000000b196e20150460000344332323438303932003865323738326237346634303238346333663437363138623062613234373663356431366363303533313862373532316431353635650600000002000000100000002900000011000000060000000000000008060000000000000011000000020000000200000000000000f107c6a5',
+  'aa1c00ab24654c010101010e416264756c27732057484f4f50000000c1f64786',
+  'aa8c004a242723a00104c503000000ef77256a087d0000344332323438303932003865323738326237346634303238346333663437363138623062613234373663356431366363303533313862373532316431353635650600000002000000100000002900000011000000060000000000000008060000000000000011000000020000000200000000000000ebc0d3a1',
+];
+
+const expectedSerial = '4C2248092';
+const expectedName = "Abdul's WHOOP";
+
+// Run all frame bytes through one reassembler using [chunker] to split the byte
+// stream, then decode every valid frame and collect serials + names.
+({List<String> serials, List<String> names}) run(
+    List<List<int>> Function(List<int>) chunker) {
+  final asm = FrameReassembler();
+  final serials = <String>[];
+  final names = <String>[];
+  final stream = <int>[];
+  for (final f in frames) {
+    stream.addAll(hexToBytes(f));
+  }
+  for (final chunk in chunker(stream)) {
+    for (final frame in asm.feed(chunk)) {
+      if (!frame.valid) continue;
+      final d = decodeFrame(frame);
+      if (d.kind != 'cmd_response') continue;
+      final hello = d.fields['hello'];
+      if (hello is HelloInfo && hello.serial != null) serials.add(hello.serial!);
+      final nm = d.fields['strap_name'];
+      if (nm is String && nm.isNotEmpty) names.add(nm);
+    }
+  }
+  return (serials: serials, names: names);
+}
+
+void main() {
+  final chunkers = <String, List<List<int>> Function(List<int>)>{
+    'one big chunk': (s) => [s],
+    'byte by byte': (s) => [for (final b in s) [b]],
+    'mtu 20': (s) => [
+          for (var i = 0; i < s.length; i += 20) s.sublist(i, (i + 20).clamp(0, s.length))
+        ],
+    'mtu 23 (split frames)': (s) => [
+          for (var i = 0; i < s.length; i += 23) s.sublist(i, (i + 23).clamp(0, s.length))
+        ],
+  };
+
+  chunkers.forEach((name, chunker) {
+    test('every read is clean under chunking: $name', () {
+      final r = run(chunker);
+      expect(r.serials.length, greaterThanOrEqualTo(3),
+          reason: 'all 3 HELLOs should decode');
+      for (final s in r.serials) {
+        expect(s, expectedSerial, reason: 'serial must never garble on a repeat');
+      }
+      expect(r.names, isNotEmpty);
+      for (final n in r.names) {
+        expect(n, expectedName, reason: 'name must never garble on a repeat');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Problem
The device serial sometimes rendered as random `?*` junk. `parseHello` found the serial by scanning for *"the first short printable run"* from a low offset — and on some firmware the volatile binary header (battery/counters/clock) contains printable bytes, so the scan latched onto that instead of the real serial.

## Root cause (verified on real data)
Decoding the captured HELLO bodies (`whoop_capture.jsonl`, band `4C2248092`) shows the serial is a **NUL-terminated ASCII token at a fixed offset — `payload[16]`** — immediately followed by the 64-char firmware commit hash. The "first printable run" heuristic was fragile; the offset is stable.

## Fix
- Read the serial as the NUL-terminated token at the fixed offset, validated (alphanumeric, 6–13 chars). Return `null` rather than garbage when it isn't there.
- Commit hash still located by content (long hex run).

## Tests
- `hello_test.dart` — 3 real HELLO bodies → `4C2248092`; short/older body → `null` (no junk).
- `reassembly_stress_test.dart` — real frames through `FrameReassembler` + `decodeFrame` under adversarial BLE chunking (whole-frame, one chunk, byte-by-byte, split-across-frames).
- Full suite green, including all **2934 parity cases**.

## Downstream
`OpenStrap/edge` consumes this — its serial display reverts to the HELLO serial (now reliable) and is what makes the `?*` go away end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)