### PR TITLE
recover: restore pre-rewind local-first work

### DIFF
--- a/lib/openstrap_protocol.dart
+++ b/lib/openstrap_protocol.dart
@@ -40,7 +40,8 @@ export 'src/commands.dart'
         cmdSendR10R11,
         cmdToggleImu,
         cmdEnableOptical,
-        cmdBuzz;
+        cmdBuzz,
+        cmdSetAlarm;
 
 // Control-plane parsers (HELLO / EVENT / METADATA / COMMAND_RESPONSE / dispatch).
 export 'src/control.dart'

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -66,3 +66,35 @@ Uint8List cmdEnableOptical(int seq, bool on) =>
     buildCommand(seq, Cmd.enableOpticalData, [revision1, on ? 0x01 : 0x00]);
 Uint8List cmdBuzz(int seq, [int pattern = hapticShortPulse]) =>
     buildCommand(seq, Cmd.runHapticsPattern, [pattern, 0, 0, 0, 0]);
+
+/// Set the band's on-device haptic alarm (SET_ALARM_TIME = 0x42). The firmware
+/// buzzes at [epochSeconds] (a wall-clock unix epoch, seconds) independently of
+/// the app, so the alarm fires even with no BLE connection.
+///
+/// Payload layout: `[u32 epoch LE][u32 0 pad]` — 8 bytes, mirroring SET_CLOCK
+/// (0x0A), which is the directly-analogous "write a wall-clock u32" command.
+///
+/// CONFIRMED:
+///   - Opcode 0x42 is the SET counterpart of GET_ALARM_TIME (0x43); DISABLE is
+///     a separate opcode (0x45). The GET_ALARM_TIME *response* decodes its epoch
+///     as a u32 LE (see parseCommandResponse → `alarm_epoch = u32(payload, 1)`),
+///     confirming the alarm time is a u32 LE unix epoch in SECONDS.
+///
+/// INFERRED (verify on real hardware):
+///   - The exact SET payload length/shape. We use the same `[u32 epoch, u32 pad]`
+///     8-byte shape as SET_CLOCK because alarm time is the same kind of value and
+///     the constants table already annotates 0x42 as `[u32 epoch LE, 0,0,0,0]`.
+///     NOTE: prior art shows SET_CLOCK's accepted length is FIRMWARE-SPECIFIC —
+///     a wrong length may ACK without latching. If the alarm fails to stick on
+///     hardware, try trimming/padding this payload to match the firmware.
+///   - The GET response has a leading byte before the epoch (decoded at offset 1,
+///     and GET is sent with a `[0x01]` read/revision byte). The SET direction is
+///     assumed NOT to need that leading byte (matching SET_CLOCK, which sends the
+///     u32 first with no toggle prefix). If SET is rejected, prepend `revision1`.
+Uint8List cmdSetAlarm(int seq, int epochSeconds) {
+  final p = Uint8List(8);
+  final bd = ByteData.sublistView(p);
+  bd.setUint32(0, epochSeconds & 0xFFFFFFFF, Endian.little);
+  // bytes [4:8] stay zero — the u32 pad, as with SET_CLOCK.
+  return buildCommand(seq, Cmd.setAlarmTime, p);
+}

--- a/test/framing_test.dart
+++ b/test/framing_test.dart
@@ -35,6 +35,30 @@ void main() {
     });
   });
 
+  group('SET_ALARM (cmdSetAlarm)', () {
+    test('round-trip: valid frame, CRCs ok, opcode 0x42, epoch decodes back', () {
+      const epoch = 1735689600; // 2025-01-01T00:00:00Z, a plausible alarm time
+      const seq = 9;
+      final raw = cmdSetAlarm(seq, epoch);
+      final f = parseFrame(raw);
+      expect(f, isNotNull);
+      expect(f!.crc8Ok, isTrue);
+      expect(f.crc32Ok, isTrue);
+      expect(f.packetType, PacketType.command);
+      expect(f.opcode, Cmd.setAlarmTime);
+      expect(f.inner[1], seq);
+      // payload starts at inner[3]: u32 epoch LE, then u32 zero pad.
+      final bd =
+          f.inner.buffer.asByteData(f.inner.offsetInBytes, f.inner.length);
+      expect(bd.getUint32(3, Endian.little), epoch);
+      expect(bd.getUint32(7, Endian.little), 0); // pad
+    });
+
+    test('SET_ALARM is NOT in dangerousCmds (normal user action)', () {
+      expect(dangerousCmds.contains(Cmd.setAlarmTime), isFalse);
+    });
+  });
+
   group('batch ACK (the fragile breaking point)', () {
     test('ACK has the exact 12-byte inner shape [0x23][seq][0x17][0x01]+token', () {
       final token = List<int>.generate(8, (i) => i + 1);


### PR DESCRIPTION
This pull request introduces a new command for setting an on-device haptic alarm, updates exports to include this command, and adds comprehensive tests to ensure its correctness. The main focus is on enabling the band to buzz at a specified wall-clock time, even without a BLE connection.

**New command implementation and exports:**

* Added `cmdSetAlarm` function in `commands.dart` to send a SET_ALARM_TIME (0x42) command, allowing the device to buzz at a specified Unix epoch time. The function constructs an 8-byte payload, mirroring the structure of the existing SET_CLOCK command.
* Exported `cmdSetAlarm` from `openstrap_protocol.dart` for use in other modules.

**Testing and validation:**

* Added a new test group in `framing_test.dart` to verify the round-trip encoding and decoding of the SET_ALARM command, check CRCs, opcode, and payload correctness, and ensure the command is not marked as dangerous.