### PR TITLE
Working alarm, extended events, v18 records + protocol hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 
+# macOS
+.DS_Store
+
 # Dart
 .dart_tool/
 .packages

--- a/lib/openstrap_protocol.dart
+++ b/lib/openstrap_protocol.dart
@@ -29,6 +29,8 @@ export 'src/framing.dart'
 export 'src/commands.dart'
     show
         buildCommand,
+        buildHistoryResultOk,
+        buildHistoryResultFail,
         buildBatchAck,
         initPackets,
         WristSelection,

--- a/lib/openstrap_protocol.dart
+++ b/lib/openstrap_protocol.dart
@@ -38,6 +38,9 @@ export 'src/commands.dart'
         cmdGetHelloModern,
         cmdAbortHistorical,
         cmdSendHistorical,
+        cmdGetClock,
+        cmdGetDataRange,
+        cmdSetClock,
         cmdReportVersionInfo,
         cmdGetBodyLocationAndStatus,
         cmdGetBatteryPackInfo,
@@ -49,7 +52,11 @@ export 'src/commands.dart'
         cmdToggleImu,
         cmdEnableOptical,
         cmdBuzz,
-        cmdSetAlarm;
+        cmdSetAlarm,
+        cmdSetAlarmSimple,
+        cmdRunAlarm,
+        cmdDisableAlarm,
+        kDefaultAlarmHaptics;
 
 // Control-plane parsers (HELLO / EVENT / METADATA / COMMAND_RESPONSE / dispatch).
 export 'src/control.dart'

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -43,7 +43,7 @@ Uint8List buildBatchAck(int seq, List<int> token) {
   return buildFrame(inner);
 }
 
-/// The 5-packet INIT handshake (HCI-snoop verbatim, seq 0..4).
+/// The 5-packet INIT handshake (hardware-verified, seq 0..4).
 /// buildCommand regenerates these byte-for-byte (protocol test asserts it).
 /// Send one-at-a-time, ~120ms apart. seq4 triggers the flash drain.
 final List<Uint8List> initPackets = [
@@ -68,6 +68,41 @@ Uint8List cmdAbortHistorical(int seq) =>
 Uint8List cmdSendHistorical(int seq) =>
     buildCommand(seq, Cmd.sendHistoricalData, const [0x00]);
 Uint8List cmdGetClock(int seq) => buildCommand(seq, Cmd.getClock, const []);
+
+/// Set the strap RTC (SET_CLOCK = 0x0A) — WHOOP-EXACT 8-byte payload,
+/// hardware-verified by the edge app (`ble_engine.dart setClock()`).
+///
+/// Payload = TWO little-endian u32s:
+///   - `[0:4]` whole seconds (unix epoch, u32 LE)
+///   - `[4:8]` SUB-seconds in units of 1/32768 s (a 32768 Hz RTC crystal):
+///     `subsec = (millis % 1000) * 32768 ~/ 1000` — 0..32767, a u16 in the low
+///     half of the second word; bytes [6:8] stay zero.
+///
+/// ⚠ SET_CLOCK payload LENGTH IS FIRMWARE-SPECIFIC (8 vs 9 bytes) and
+/// load-bearing: a wrong-length set is ACK'd but NOT latched → the RTC stays
+/// "lost", the strap refuses to serve type-47 history and records come back
+/// dated to 1971. This builder emits the 8-byte form, verified on real
+/// hardware. After sending, read the clock back (GET_CLOCK,
+/// [cmdGetClock]) to confirm it latched.
+///
+/// [now] defaults to `DateTime.now()`; pass a fixed instant for tests.
+Uint8List cmdSetClock(int seq, {DateTime? now}) {
+  final ms = (now ?? DateTime.now()).millisecondsSinceEpoch;
+  final sec = ms ~/ 1000;
+  final subsec = ((ms % 1000) * 32768) ~/ 1000; // 0..32767, 1/32768 s units
+  final payload = <int>[
+    sec & 0xff,
+    (sec >> 8) & 0xff,
+    (sec >> 16) & 0xff,
+    (sec >> 24) & 0xff,
+    subsec & 0xff,
+    (subsec >> 8) & 0xff,
+    0,
+    0,
+  ];
+  return buildCommand(seq, Cmd.setClock, payload);
+}
+
 Uint8List cmdGetDataRange(int seq) =>
     buildCommand(seq, Cmd.getDataRange, const [0x00]);
 Uint8List cmdReportVersionInfo(int seq) =>
@@ -103,6 +138,12 @@ Uint8List cmdSelectWrist(int seq, WristSelection selection) =>
 // persist (0x9A); persistent causes the stuck-green-LED footgun ().
 Uint8List cmdToggleHr(int seq, bool on) =>
     buildCommand(seq, Cmd.toggleRealtimeHr, [on ? 0x01 : 0x00]);
+
+/// Toggle the realtime raw (R10/R11) stream (SEND_R10_R11_REALTIME = 0x3F).
+///
+/// NOTE: sending this with payload `[0x00]` (i.e. `cmdSendR10R11(seq, false)`)
+/// is the REAL persistent raw-flood OFF-switch — the off state persists across
+/// reconnects. STOP_RAW_DATA (0x52) does nothing. (PROTOCOL_FINDINGS.md:168-169)
 Uint8List cmdSendR10R11(int seq, bool on) =>
     buildCommand(seq, Cmd.sendR10R11Realtime, [on ? 0x01 : 0x00]);
 Uint8List cmdToggleImu(int seq, bool on) =>
@@ -112,34 +153,134 @@ Uint8List cmdEnableOptical(int seq, bool on) =>
 Uint8List cmdBuzz(int seq, [int pattern = hapticShortPulse]) =>
     buildCommand(seq, Cmd.runHapticsPattern, [pattern, 0, 0, 0, 0]);
 
-/// Set the band's on-device haptic alarm (SET_ALARM_TIME = 0x42). The firmware
-/// buzzes at [epochSeconds] (a wall-clock unix epoch, seconds) independently of
-/// the app, so the alarm fires even with no BLE connection.
+// ── On-device haptic alarm (SET_ALARM_TIME = 0x42) ─────────────────────────
+//
+// The strap runs a wall-clock alarm entirely on-device, so it buzzes at the
+// scheduled time even with no phone connected. The alarm time is a unix epoch
+// split into whole seconds + a 1/32768-s sub-second remainder, exactly like
+// SET_CLOCK (0x0A) — the strap's RTC ticks at 32768 Hz.
+//
+// The alarm has TWO on-wire forms, both hardware-verified from our own device
+// captures:
+//   • a SHORT form ([cmdSetAlarmSimple]) that carries only the time, and
+//   • a RICH form ([cmdSetAlarm]) that carries the time PLUS a haptic waveform
+//     pattern.
+// On real hardware only the RICH form actually makes the strap buzz: a short
+// "time only" write is accepted and ACK'd but the strap never fires it (there
+// is no waveform to play). Our earlier 8-byte `[u32 epoch][u32 pad]` attempt
+// silently failed for exactly this reason. Prefer [cmdSetAlarm].
+
+/// The strap's built-in alarm buzz. Two short waveform effects (47, 152) played
+/// with no per-effect loop, the overall waveform looped 7×, for 30 s — this is
+/// the default we observed the strap firing for its on-device wake alarm.
+const List<int> kDefaultAlarmHaptics = <int>[
+  47, 152, 0, 0, 0, 0, 0, 0, // 8× waveform-effect slots (2 active, 6 idle)
+  0, 0, //                       loopControlForEffects (u16 LE) = 0
+  7, //                          overallWaveformLoopControl = 7
+  30, //                         alarmDurationInSeconds = 30
+];
+
+// Split a wall-clock instant into the strap's (u32 seconds, u16 sub-seconds)
+// representation. Sub-seconds are in units of 1/32768 s (32768 Hz RTC crystal),
+// identical to SET_CLOCK.
+int _alarmEpochSec(DateTime when) => when.millisecondsSinceEpoch ~/ 1000;
+int _alarmSubsec(DateTime when) =>
+    ((when.millisecondsSinceEpoch % 1000) * 32768) ~/ 1000; // 0..32767
+
+/// SHORT alarm form (SET_ALARM_TIME = 0x42).
 ///
-/// Payload layout: `[u32 epoch LE][u32 0 pad]` — 8 bytes, mirroring SET_CLOCK
-/// (0x0A), which is the directly-analogous "write a wall-clock u32" command.
+/// Payload = 7 bytes: `[0x01][u32 epoch-seconds LE][u16 sub-seconds LE]`.
+///   - `0x01` — the form/revision marker for the time-only alarm.
+///   - epoch seconds — `when` as a unix epoch, u32 LE.
+///   - sub-seconds — `(millis % 1000) * 32768 ~/ 1000`, u16 LE (1/32768 s units).
 ///
-/// CONFIRMED:
-///   - Opcode 0x42 is the SET counterpart of GET_ALARM_TIME (0x43); DISABLE is
-///     a separate opcode (0x45). The GET_ALARM_TIME *response* decodes its epoch
-///     as a u32 LE (see parseCommandResponse → `alarm_epoch = u32(payload, 1)`),
-///     confirming the alarm time is a u32 LE unix epoch in SECONDS.
-///
-/// INFERRED (verify on real hardware):
-///   - The exact SET payload length/shape. We use the same `[u32 epoch, u32 pad]`
-///     8-byte shape as SET_CLOCK because alarm time is the same kind of value and
-///     the constants table already annotates 0x42 as `[u32 epoch LE, 0,0,0,0]`.
-///     NOTE: prior art shows SET_CLOCK's accepted length is FIRMWARE-SPECIFIC —
-///     a wrong length may ACK without latching. If the alarm fails to stick on
-///     hardware, try trimming/padding this payload to match the firmware.
-///   - The GET response has a leading byte before the epoch (decoded at offset 1,
-///     and GET is sent with a `[0x01]` read/revision byte). The SET direction is
-///     assumed NOT to need that leading byte (matching SET_CLOCK, which sends the
-///     u32 first with no toggle prefix). If SET is rejected, prepend `revision1`.
-Uint8List cmdSetAlarm(int seq, int epochSeconds) {
-  final p = Uint8List(8);
-  final bd = ByteData.sublistView(p);
-  bd.setUint32(0, epochSeconds & 0xFFFFFFFF, Endian.little);
-  // bytes [4:8] stay zero — the u32 pad, as with SET_CLOCK.
+/// ⚠ This form sets the alarm TIME but ships no haptic waveform, so on real
+/// hardware the strap ACKs it yet never buzzes. Use [cmdSetAlarm] to actually
+/// arm a firing alarm; this is kept for parity / diagnostics only.
+Uint8List cmdSetAlarmSimple(int seq, DateTime when) {
+  final sec = _alarmEpochSec(when);
+  final subsec = _alarmSubsec(when);
+  final p = <int>[
+    0x01,
+    sec & 0xff,
+    (sec >> 8) & 0xff,
+    (sec >> 16) & 0xff,
+    (sec >> 24) & 0xff,
+    subsec & 0xff,
+    (subsec >> 8) & 0xff,
+  ];
   return buildCommand(seq, Cmd.setAlarmTime, p);
+}
+
+/// RICH alarm form (SET_ALARM_TIME = 0x42) — THE form that actually fires.
+///
+/// Payload = 20 bytes:
+/// ```
+///   [0x04]                     form/revision marker for the rich alarm
+///   [u8  index]                alarm slot index (default 0)
+///   [u32 epoch-seconds LE]     when, as a unix epoch (u32 LE)
+///   [u16 sub-seconds   LE]     (millis % 1000) * 32768 ~/ 1000 (1/32768 s)
+///   [12-byte haptic pattern]   see [kDefaultAlarmHaptics] for the layout
+/// ```
+/// The 12-byte haptic pattern is:
+/// ```
+///   [8× u8 waveform-effect]    the effect sequence to play (0 = idle slot)
+///   [u16 loopControl LE]       per-effect loop control
+///   [u8  overallLoop]          how many times to loop the whole waveform
+///   [u8  durationSeconds]      max time to keep buzzing
+/// ```
+///
+/// A haptic pattern is REQUIRED for the alarm to actually buzz — the time-only
+/// [cmdSetAlarmSimple] form ACKs without firing. [hapticPattern] defaults to
+/// [kDefaultAlarmHaptics] (the strap's stock wake buzz); pass your own 12 bytes
+/// to customise. The strap confirms the alarm latched via the
+/// STRAP_DRIVEN_ALARM_SET (56) event and its firing via
+/// STRAP_DRIVEN_ALARM_EXECUTED (57) / HAPTICS_FIRED (60).
+Uint8List cmdSetAlarm(
+  int seq,
+  DateTime when, {
+  int index = 0,
+  List<int>? hapticPattern,
+}) {
+  final pattern = hapticPattern ?? kDefaultAlarmHaptics;
+  if (pattern.length != 12) {
+    throw ArgumentError.value(
+        pattern.length, 'hapticPattern.length', 'haptic pattern must be 12 bytes');
+  }
+  final sec = _alarmEpochSec(when);
+  final subsec = _alarmSubsec(when);
+  final p = <int>[
+    0x04,
+    index & 0xff,
+    sec & 0xff,
+    (sec >> 8) & 0xff,
+    (sec >> 16) & 0xff,
+    (sec >> 24) & 0xff,
+    subsec & 0xff,
+    (subsec >> 8) & 0xff,
+    ...pattern.map((b) => b & 0xff),
+  ];
+  return buildCommand(seq, Cmd.setAlarmTime, p);
+}
+
+/// Fire / test the alarm haptics immediately (RUN_ALARM = 0x44).
+///
+/// Two forms:
+///   - revision 1 (default, [mode] == null): payload `[0x01]`.
+///   - revision 2 ([mode] set): payload `[0x02][u8 mode]`, where `mode` selects
+///     the run behaviour understood by the firmware.
+Uint8List cmdRunAlarm(int seq, {int? mode}) {
+  final p = mode == null ? const [0x01] : [0x02, mode & 0xff];
+  return buildCommand(seq, Cmd.runAlarm, p);
+}
+
+/// Disable / cancel the on-device alarm (DISABLE_ALARM = 0x45).
+///
+/// Payload is the revision byte:
+///   - revision 1 (default): `[0x01]`.
+///   - revision 2: `[0x02][0xFF]` — the trailing 0xFF is the firmware's
+///     "clear all" sentinel for the rev-2 disable.
+Uint8List cmdDisableAlarm(int seq, {int revision = 1}) {
+  final p = revision == 2 ? const [0x02, 0xFF] : [revision & 0xff];
+  return buildCommand(seq, Cmd.disableAlarm, p);
 }

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -25,11 +25,10 @@ Uint8List buildCommand(int seq, int opcode,
   return buildFrame(inner);
 }
 
-/// The historical-sync acknowledgement (cmd 0x17).
-/// Inner = [0x23][seq][0x17][0x01] + token(8B)  -> 12-byte inner, 20-byte frame.
-/// `token` is bytes inner[13:21] of the HistoryEnd METADATA marker.
-/// THIS IS THE FRAGILE BREAKING POINT — verified byte-exact ().
-Uint8List buildBatchAck(int seq, List<int> token) {
+/// WHOOP's positive historical-burst result (cmd 0x17).
+/// Inner = [0x23][seq][0x17][0x01] + token(8B).
+/// `token` is the two 4-byte slices from the HistoryEnd METADATA marker.
+Uint8List buildHistoryResultOk(int seq, List<int> token) {
   if (token.length != 8) {
     throw ArgumentError('batch token must be 8 bytes, got ${token.length}');
   }
@@ -42,6 +41,16 @@ Uint8List buildBatchAck(int seq, List<int> token) {
   ];
   return buildFrame(inner);
 }
+
+/// WHOOP's negative historical-burst result (cmd 0x17).
+/// Payload is a single FAILURE byte. The reference builder allocates one spare
+/// trailing byte, but the band only requires the result code itself.
+Uint8List buildHistoryResultFail(int seq) =>
+    buildCommand(seq, Cmd.historicalDataResult, const [0x00]);
+
+/// Legacy alias used by the app transport.
+Uint8List buildBatchAck(int seq, List<int> token) =>
+    buildHistoryResultOk(seq, token);
 
 /// The 5-packet INIT handshake (HCI-snoop verbatim, seq 0..4).
 /// buildCommand regenerates these byte-for-byte (protocol test asserts it).

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -107,6 +107,8 @@ class EventId {
   static const int flashInitComplete = 28;
   static const int extendedBatteryInformation = 63;
   static const int highFreqSyncPrompt = 96;
+  static const int highFreqSyncEnabled = 97;
+  static const int highFreqSyncDisabled = 98;
 
   static String name(int id) {
     switch (id) {
@@ -136,6 +138,10 @@ class EventId {
         return 'EXTENDED_BATTERY_INFORMATION';
       case highFreqSyncPrompt:
         return 'HIGH_FREQ_SYNC_PROMPT';
+      case highFreqSyncEnabled:
+        return 'HIGH_FREQ_SYNC_ENABLED';
+      case highFreqSyncDisabled:
+        return 'HIGH_FREQ_SYNC_DISABLED';
       default:
         return 'EVENT_$id';
     }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -34,6 +34,9 @@ class PacketType {
 /// Command opcodes (inside a 0x23 COMMAND) —. Subset we use.
 class Cmd {
   static const int linkValid = 0x01;
+  // Report the highest wire-protocol revision the strap understands. Response
+  // carries the max protocol version — used for firmware/feature gating.
+  static const int getMaxProtocolVersion = 0x02;
   static const int toggleRealtimeHr = 0x03;
   static const int reportVersionInfo = 0x07;
   static const int setClock =
@@ -42,15 +45,30 @@ class Cmd {
   static const int abortHistoricalTransmits = 0x14;
   static const int sendHistoricalData = 0x16;
   static const int historicalDataResult = 0x17; // the batch ACK
-  static const int forceTrim = 0x19; // DANGER — never send
+  // DANGER — never send. Body is NOT empty: two LE i32 range args
+  // (full erase = both 0xFEFEFEFE). See PROTOCOL_FINDINGS.md.
+  static const int forceTrim = 0x19;
   static const int getBatteryLevel = 0x1A;
   static const int rebootStrap = 0x1D; // DANGER
+  // Hard power-cycle the strap (like pulling the battery). DANGER — never
+  // auto-fire; only a deliberate, user-driven recovery action.
+  static const int powerCycleStrap = 0x20; // DANGER
   static const int setReadPointer = 0x21;
   static const int getDataRange = 0x22;
   static const int getHelloHarvard = 0x23;
+  // Firmware-load opcodes (Cmd opcode space — distinct from PacketType 0x24
+  // COMMAND_RESPONSE, which is inner[0], not a command opcode).
+  // DANGER — never send (per PROTOCOL_FINDINGS.md destructive list).
+  static const int startFirmwareLoad = 0x24; // DANGER
+  static const int loadFirmwareData = 0x25; // DANGER
+  static const int processFirmwareImage = 0x26; // DANGER
   static const int sendR10R11Realtime = 0x3F;
-  static const int setAlarmTime = 0x42; // [u32 epoch LE, 0,0,0,0] — smart alarm
+  // On-device haptic alarm. SET carries a wall-clock epoch + a haptic waveform
+  // pattern (see cmdSetAlarm in commands.dart for the exact, hardware-verified
+  // layout). The short "epoch only" form ACKs but never buzzes.
+  static const int setAlarmTime = 0x42;
   static const int getAlarmTime = 0x43;
+  static const int runAlarm = 0x44; // fire/test the alarm haptics immediately
   static const int disableAlarm = 0x45;
   static const int getAdvertisingNameHarvard = 0x4C;
   static const int setAdvertisingNameHarvard =
@@ -75,6 +93,10 @@ const Set<int> dangerousCmds = {
   Cmd.forceTrim,
   Cmd.togglePersistentR21,
   Cmd.rebootStrap,
+  Cmd.powerCycleStrap,
+  Cmd.startFirmwareLoad,
+  Cmd.loadFirmwareData,
+  Cmd.processFirmwareImage,
 };
 
 /// Historical-data record type (inner[1] of a 0x2F / data packet).
@@ -101,10 +123,33 @@ class EventId {
   static const int wristOff = 10;
   static const int rtcLost = 13;
   static const int doubleTap = 14;
+  static const int boot = 15;
+  // The strap's RTC latched a new wall-clock time (emitted after a successful
+  // SET_CLOCK). This is our authoritative confirmation the clock stuck.
+  static const int setRtc = 16;
+  static const int temperatureLevel = 17;
   static const int batteryPackConnected = 21;
   static const int batteryPackRemoved = 22;
   static const int bleBonded = 23;
+  // Full-flash trim (data erase) started / finished on the strap.
+  static const int trimAllData = 26;
+  static const int trimAllDataEnded = 27;
   static const int flashInitComplete = 28;
+  // Optical / accel front-end saturation warnings.
+  static const int ch1Saturation = 40;
+  static const int ch2Saturation = 41;
+  static const int accelSaturation = 42;
+  static const int rawDataCollectionOn = 46;
+  static const int rawDataCollectionOff = 47;
+  // Alarm lifecycle events — how the strap tells us the alarm latched and fired.
+  // "strap-driven" = the strap's own scheduled alarm; "app-driven" = one we
+  // triggered over BLE. These 56–59 events are the confirmation that our
+  // SET_ALARM_TIME write actually took (the older short form never emitted them).
+  static const int strapDrivenAlarmSet = 56;
+  static const int strapDrivenAlarmExecuted = 57;
+  static const int appDrivenAlarmExecuted = 58;
+  static const int strapDrivenAlarmDisabled = 59;
+  static const int hapticsFired = 60;
   static const int extendedBatteryInformation = 63;
   static const int highFreqSyncPrompt = 96;
 
@@ -124,14 +169,44 @@ class EventId {
         return 'RTC_LOST';
       case doubleTap:
         return 'DOUBLE_TAP';
+      case boot:
+        return 'BOOT';
+      case setRtc:
+        return 'SET_RTC';
+      case temperatureLevel:
+        return 'TEMPERATURE_LEVEL';
       case batteryPackConnected:
         return 'BATTERY_PACK_CONNECTED';
       case batteryPackRemoved:
         return 'BATTERY_PACK_REMOVED';
       case bleBonded:
         return 'BLE_BONDED';
+      case trimAllData:
+        return 'TRIM_ALL_DATA';
+      case trimAllDataEnded:
+        return 'TRIM_ALL_DATA_ENDED';
       case flashInitComplete:
         return 'FLASH_INIT_COMPLETE';
+      case ch1Saturation:
+        return 'CH1_SATURATION_DETECTED';
+      case ch2Saturation:
+        return 'CH2_SATURATION_DETECTED';
+      case accelSaturation:
+        return 'ACCELEROMETER_SATURATION_DETECTED';
+      case rawDataCollectionOn:
+        return 'RAW_DATA_COLLECTION_ON';
+      case rawDataCollectionOff:
+        return 'RAW_DATA_COLLECTION_OFF';
+      case strapDrivenAlarmSet:
+        return 'STRAP_DRIVEN_ALARM_SET';
+      case strapDrivenAlarmExecuted:
+        return 'STRAP_DRIVEN_ALARM_EXECUTED';
+      case appDrivenAlarmExecuted:
+        return 'APP_DRIVEN_ALARM_EXECUTED';
+      case strapDrivenAlarmDisabled:
+        return 'STRAP_DRIVEN_ALARM_DISABLED';
+      case hapticsFired:
+        return 'HAPTICS_FIRED';
       case extendedBatteryInformation:
         return 'EXTENDED_BATTERY_INFORMATION';
       case highFreqSyncPrompt:

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -316,15 +316,37 @@ class EventInfo {
   final int eventId;
   final String name;
   final int tsEpoch;
+
+  /// Sub-second remainder of the event timestamp, u16 @ [8], in units of
+  /// 1/32768 s (the 32768 Hz RTC crystal). 0 when the frame is too short.
+  final int tsSubsec;
+
+  /// The event-specific body — the frame from offset [12] onward. Empty when
+  /// the frame carries no body. Kept raw so callers can decode per event id.
+  final Uint8List body;
+
   final Map<String, dynamic> decoded;
-  EventInfo(this.eventId, this.name, this.tsEpoch, this.decoded);
+  EventInfo(
+    this.eventId,
+    this.name,
+    this.tsEpoch,
+    this.decoded, {
+    this.tsSubsec = 0,
+    Uint8List? body,
+  }) : body = body ?? Uint8List(0);
 }
 
 EventInfo? parseEvent(Uint8List inner) {
   if (inner.length < 4 || inner[0] != PacketType.event) return null;
   final eid = u16(inner, 2);
   final name = EventId.name(eid);
+  // Timestamp: whole seconds u32 @ [4], sub-seconds u16 @ [8]; the event body
+  // begins at [12]. All guarded by length so short frames degrade cleanly.
   final ts = inner.length >= 8 ? u32(inner, 4) : 0;
+  final subsec = inner.length >= 10 ? u16(inner, 8) : 0;
+  final body = inner.length > 12
+      ? Uint8List.sublistView(inner, 12)
+      : Uint8List(0);
   final dec = <String, dynamic>{};
   switch (eid) {
     case EventId.chargingOn:
@@ -343,7 +365,7 @@ EventInfo? parseEvent(Uint8List inner) {
       dec['double_tap'] = true;
       break;
   }
-  return EventInfo(eid, name, ts, dec);
+  return EventInfo(eid, name, ts, dec, tsSubsec: subsec, body: body);
 }
 
 // ── COMMAND_RESPONSE (0x24) ──────────────────────────────────────────────────

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -342,6 +342,15 @@ EventInfo? parseEvent(Uint8List inner) {
     case EventId.doubleTap:
       dec['double_tap'] = true;
       break;
+    case EventId.highFreqSyncPrompt:
+      dec['high_freq_sync'] = 'prompt';
+      break;
+    case EventId.highFreqSyncEnabled:
+      dec['high_freq_sync'] = 'enabled';
+      break;
+    case EventId.highFreqSyncDisabled:
+      dec['high_freq_sync'] = 'disabled';
+      break;
   }
   return EventInfo(eid, name, ts, dec);
 }
@@ -490,9 +499,16 @@ List<int>? _plausibleUnixRange(Uint8List payload) {
 class MetaMarker {
   final int sub;
   final String name;
+  final int? expectedPacketCount;
   final Uint8List? token; // 8-byte batch token (HistoryEnd only)
   final int? batchId;
-  MetaMarker(this.sub, this.name, this.token, this.batchId);
+  MetaMarker(
+    this.sub,
+    this.name,
+    this.expectedPacketCount,
+    this.token,
+    this.batchId,
+  );
 }
 
 MetaMarker? parseMetadata(Uint8List inner) {
@@ -512,14 +528,18 @@ MetaMarker? parseMetadata(Uint8List inner) {
     default:
       name = 'META_$sub';
   }
+  int? expectedPacketCount;
   Uint8List? token;
   int? batchId;
+  if (sub == SyncMeta.historyEnd && inner.length >= 13) {
+    expectedPacketCount = u32(inner, 9);
+  }
   if (sub == SyncMeta.historyEnd && inner.length >= 21) {
     token =
         Uint8List.fromList(inner.sublist(13, 21)); // the 8 bytes the ACK echoes
     batchId = u32(inner, 17);
   }
-  return MetaMarker(sub, name, token, batchId);
+  return MetaMarker(sub, name, expectedPacketCount, token, batchId);
 }
 
 // ── decode_frame dispatch (for live UI / logging) ────────────────────────────

--- a/lib/src/records.dart
+++ b/lib/src/records.dart
@@ -109,6 +109,11 @@ double _gravI16(Uint8List inner, int offset) {
   return _round(v / 16384.0, 4);
 }
 
+/// Decode a v25 (PPG-derived) historical record. Unlike v24, the v25 field map
+/// comes purely from our own device captures — it has no independent
+/// cross-reference, so it is LOWER-CONFIDENCE: we decode timing + gravity and
+/// deliberately leave HR at 0 (v25 carries no honest 1 Hz beat). It is gated on
+/// a gravity-magnitude sanity check to avoid emitting garbage.
 R24? _parseV25(Uint8List inner) {
   if (inner.length < 75) return null;
   final view = _view(inner);
@@ -140,8 +145,47 @@ R24? _parseV25(Uint8List inner) {
   );
 }
 
+/// HR-byte offset within the record inner, keyed by the layout version byte
+/// (inner[1]). The header (counter @ [3], ts @ [7], subsec @ [11]) is shared
+/// across versions; only the HR byte moves. Established from our own hardware
+/// captures across the layout versions the strap has served us.
+const Map<int, int> _hrOffsetByVersion = {
+  7: 27,
+  9: 17,
+  12: 17,
+  18: 14,
+  24: 17,
+};
+
+/// Physiological plausibility gate for a best-effort decode: the gravity vector
+/// must have magnitude ≈ 1 g (0.5–1.8 g) AND HR must be in a live human range
+/// (25–230 bpm). Used to guard speculative decodes (unrecognised versions, or
+/// versions where only the HR offset — not the full field map — is confirmed).
+/// Compared on magnitude-squared to avoid a sqrt.
+bool _physiologicallyPlausible(List<double> accelG, int hr) {
+  if (hr < 25 || hr > 230) return false;
+  if (accelG.length != 3) return false;
+  final magSq = accelG[0] * accelG[0] +
+      accelG[1] * accelG[1] +
+      accelG[2] * accelG[2];
+  return magSq >= 0.25 && magSq <= 3.24; // 0.5 g .. 1.8 g
+}
+
 /// Decode a WHOOP 4 historical biometric record. `inner` starts at the
-/// packet-type byte. Auto-routes supported layout versions (`24`, `25`).
+/// packet-type byte.
+///
+/// Routing:
+///   - v25 → the PPG-derived layout ([_parseV25]).
+///   - v24 / v12 → our hardware-validated field map, returned as-is.
+///   - v18 / v9 / v7 → the SAME field map but with the HR byte read at that
+///     version's offset (only the HR offset is independently confirmed for
+///     these, so the decode is returned only if it passes a physiological
+///     plausibility gate — otherwise null).
+///   - any other version → treated as an unknown/future layout: we attempt the
+///     v24 field map and return it only if it is physiologically plausible.
+///     This degrades a firmware layout change to a validated best-effort read
+///     instead of emitting garbage.
+///
 /// Returns null if too short or if the version-specific decode fails.
 R24? parseR24(Uint8List inner) {
   if (inner.length < 2) {
@@ -150,9 +194,23 @@ R24? parseR24(Uint8List inner) {
 
   final version = inner[1];
   if (version == 25) return _parseV25(inner);
-  if (version != 24 && version != 12) {
-    return null;
-  }
+
+  // v24 / v12 are our validated map and are trusted verbatim; every other
+  // version is a best-effort decode gated on physiological plausibility.
+  final trusted = version == 24 || version == 12;
+  final hrOffset = _hrOffsetByVersion[version] ?? 17;
+  return _parseV24Layout(inner, version, hrOffset: hrOffset, validate: !trusted);
+}
+
+/// Decode the WHOOP 4 v24 field map with a parameterised HR offset. When
+/// [validate] is set the result is returned only if it passes
+/// [_physiologicallyPlausible]; otherwise (v24/v12) it is returned verbatim.
+R24? _parseV24Layout(
+  Uint8List inner,
+  int version, {
+  required int hrOffset,
+  required bool validate,
+}) {
   if (inner.length < 89) {
     return null;
   }
@@ -170,21 +228,28 @@ R24? parseR24(Uint8List inner) {
     if (v > 0) rrIntervalsMs.add(v);
   }
 
+  final hr = inner[hrOffset];
+  final accelG = [
+    _round(view.getFloat32(36, Endian.little), 4),
+    _round(view.getFloat32(40, Endian.little), 4),
+    _round(view.getFloat32(44, Endian.little), 4),
+  ];
+
+  if (validate && !_physiologicallyPlausible(accelG, hr)) {
+    return null;
+  }
+
   return R24(
     histVersion: version,
     tsEpoch: view.getUint32(7, Endian.little),
     tsSubsec: view.getUint16(11, Endian.little),
     counter: view.getUint32(3, Endian.little),
-    hr: inner[17],
+    hr: hr,
     rrCount: rrCount,
     rrIntervalsMs: rrIntervalsMs,
     ppgGreen: view.getUint16(29, Endian.little),
     ppgRedIr: view.getUint16(31, Endian.little),
-    accelG: [
-      _round(view.getFloat32(36, Endian.little), 4),
-      _round(view.getFloat32(40, Endian.little), 4),
-      _round(view.getFloat32(44, Endian.little), 4),
-    ],
+    accelG: accelG,
     skinContact: inner[51],
     spo2RedRaw: view.getUint16(64, Endian.little),
     spo2IrRaw: view.getUint16(66, Endian.little),

--- a/lib/src/records.dart
+++ b/lib/src/records.dart
@@ -1,43 +1,50 @@
 // records.dart — 1:1 Dart port of ts/records.ts.
-// Owns the Type-24 historical biometric record (96 bytes, 1 Hz) decode.
+// Owns the WHOOP historical biometric record decode used by type-47 payloads.
 // PURE Dart — dart:typed_data only.
 
 import 'dart:typed_data';
 
 /// Decoded Type-24 historical biometric record.
 class R24 {
-  final int histVersion; // historical layout version byte @ [1]
-  final int tsEpoch; // unix seconds @ [7:11]
-  final int tsSubsec; // sub-seconds @ [11:13]
-  final int counter; // record counter @ [3:7]
-  final int hr; // heart rate bpm @ [17]
+  final int histVersion; // historical layout version byte @ inner[1] (frame[5])
+  final int tsEpoch; // unix seconds @ inner[7:11] (frame[11:15])
+  final int tsSubsec; // sub-seconds @ inner[11:13] (frame[15:17], v24/v12)
+  final int counter; // record counter @ inner[3:7] (frame[7:11])
+  final int hr; // heart rate bpm @ inner[17] (frame[21], v24/v12)
 
   /// Beat-to-beat (R-R) intervals in ms for this 1 s record, 0–4 of them.
   final int rrCount;
   final List<int> rrIntervalsMs;
 
-  /// Raw green-LED PPG ADC count @ [29].
+  /// Raw green-LED PPG ADC count @ inner[29] (frame[33]).
   final int ppgGreen;
 
-  /// Raw red/IR-LED PPG ADC count @ [31].
+  /// Raw red/IR-LED PPG ADC count @ inner[31] (frame[35]).
   final int ppgRedIr;
 
-  /// Gravity/accel vector (g), 3× float32 @ [36:48], rounded to 4 decimals.
+  /// Gravity/accel vector (g), 3x float32 @ inner[36:48] (frame[40:52]),
+  /// rounded to 4 decimals.
   final List<double> accelG;
 
-  /// Skin-contact quality @ [51] (u8, 0–198).
+  /// Skin-contact quality @ inner[51] (frame[55]) (u8, 0-198).
   final int skinContact;
 
-  /// Raw red-channel ADC @ [64] (relative).
+  /// Raw red-channel ADC @ inner[64] (frame[68], WHOOP 4 v24/v12).
+  ///
+  /// Important: many reverse-engineering notes quote WHOOP offsets in
+  /// FRAME-absolute coordinates. `parseR24` receives the INNER record starting
+  /// at packet type `0x2f`, so every frame-absolute offset is 4 bytes lower
+  /// here. That is why the v24 optical block is 64/66/68/70 in this file but
+  /// 68/70/72/74 in frame-absolute docs.
   final int spo2RedRaw;
 
-  /// Raw IR-channel ADC @ [66] (relative).
+  /// Raw IR-channel ADC @ inner[66] (frame[70], WHOOP 4 v24/v12).
   final int spo2IrRaw;
 
-  /// Raw skin-temperature ADC @ [68] (relative).
+  /// Raw skin-temperature ADC @ inner[68] (frame[72], WHOOP 4 v24/v12).
   final int skinTempRaw;
 
-  /// Raw ambient-light ADC @ [70] (relative).
+  /// Raw ambient-light ADC @ inner[70] (frame[74], WHOOP 4 v24/v12).
   final int ambientRaw;
 
   /// Untouched payload [13:] as hex — kept for re-decode as the map improves.
@@ -112,9 +119,19 @@ double _gravI16(Uint8List inner, int offset) {
 R24? _parseV25(Uint8List inner) {
   if (inner.length < 75) return null;
   final view = _view(inner);
-  // The documented v25 layout uses absolute frame offsets. Our decoder
+  // The documented v25 layout uses frame-absolute offsets. Our decoder
   // receives the inner record starting at packet type 0x2f, so subtract the
   // 4-byte transport prefix: unix 11->7 and gravity 73/75/77->69/71/73.
+  //
+  // What is KNOWN for v25:
+  //   - unix is stable at inner[7:11]
+  //   - gravity is stable at inner[69/71/73] as i16/16384
+  // What is NOT solved here:
+  //   - exact red/IR scalar offsets inside the v25 optical region
+  //   - any true SpO2% decode
+  //
+  // So v25 intentionally surfaces motion + time only and leaves the optical
+  // fields zero rather than inventing a bogus decode.
   final gx = _gravI16(inner, 69);
   final gy = _gravI16(inner, 71);
   final gz = _gravI16(inner, 73);
@@ -140,8 +157,12 @@ R24? _parseV25(Uint8List inner) {
   );
 }
 
-/// Decode a WHOOP 4 historical biometric record. `inner` starts at the
-/// packet-type byte. Auto-routes supported layout versions (`24`, `25`).
+/// Decode a WHOOP historical biometric record. `inner` starts at the
+/// packet-type byte (frame[4]), not the SOF.
+///
+/// Supported layout versions:
+///   - v24 / v12: WHOOP 4 scalar optical block is decoded
+///   - v25: unix + gravity are decoded; optical fields stay zero on purpose
 /// Returns null if too short or if the version-specific decode fails.
 R24? parseR24(Uint8List inner) {
   if (inner.length < 2) {

--- a/test/decoder_test.dart
+++ b/test/decoder_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:openstrap_protocol/openstrap_protocol.dart';
 import 'package:test/test.dart';
@@ -21,7 +22,8 @@ void main() {
         }
       }
       if (f == null) {
-        throw StateError('whoop_hist.jsonl fixture not found (looked in $candidates)');
+        throw StateError(
+            'whoop_hist.jsonl fixture not found (looked in $candidates)');
       }
       records = f
           .readAsLinesSync()
@@ -45,6 +47,20 @@ void main() {
       expect((r.accelG[0] - -0.150).abs() < 0.001, isTrue);
       expect((r.accelG[1] - -0.331).abs() < 0.001, isTrue);
       expect((r.accelG[2] - 1.001).abs() < 0.001, isTrue);
+    });
+
+    test('v24 optical offsets are inner-relative, not frame-absolute', () {
+      final r = parseR24(hexToBytes(records[0]['hex'] as String))!;
+      final b = hexToBytes(records[0]['hex'] as String);
+      final view = b.buffer.asByteData(b.offsetInBytes, b.lengthInBytes);
+
+      // `parseR24` consumes the inner record starting at packet type 0x2f.
+      // So the WHOOP 4 v24 optical block documented at frame[68/70/72/74]
+      // is read here at inner[64/66/68/70].
+      expect(r.spo2RedRaw, view.getUint16(64, Endian.little));
+      expect(r.spo2IrRaw, view.getUint16(66, Endian.little));
+      expect(r.skinTempRaw, view.getUint16(68, Endian.little));
+      expect(r.ambientRaw, view.getUint16(70, Endian.little));
     });
 
     test('all 550 records decode without throwing / null', () {

--- a/test/framing_test.dart
+++ b/test/framing_test.dart
@@ -10,7 +10,7 @@ String _hex(List<int> b) =>
 
 void main() {
   group('framing + CRC (INIT byte-exactness)', () {
-    // HCI-snoop verbatim. Matching them validates buildFrame, crc8, crc32.
+    // Hardware-verified INIT bytes. Matching them validates buildFrame, crc8, crc32.
     const expected = [
       'aa0800a823002300ada86a2d',
       'aa0800a823014c00f2b5cdce',
@@ -39,7 +39,8 @@ void main() {
     test('round-trip: valid frame, CRCs ok, opcode 0x42, epoch decodes back', () {
       const epoch = 1735689600; // 2025-01-01T00:00:00Z, a plausible alarm time
       const seq = 9;
-      final raw = cmdSetAlarm(seq, epoch);
+      final when = DateTime.fromMillisecondsSinceEpoch(epoch * 1000);
+      final raw = cmdSetAlarm(seq, when);
       final f = parseFrame(raw);
       expect(f, isNotNull);
       expect(f!.crc8Ok, isTrue);
@@ -47,11 +48,15 @@ void main() {
       expect(f.packetType, PacketType.command);
       expect(f.opcode, Cmd.setAlarmTime);
       expect(f.inner[1], seq);
-      // payload starts at inner[3]: u32 epoch LE, then u32 zero pad.
+      // Rich form: [0x04][index][u32 epoch LE][u16 subsec LE][12-byte pattern].
+      expect(f.inner[3], 0x04); // rich-form marker (the form that fires)
+      expect(f.inner[4], 0x00); // default slot index
       final bd =
           f.inner.buffer.asByteData(f.inner.offsetInBytes, f.inner.length);
-      expect(bd.getUint32(3, Endian.little), epoch);
-      expect(bd.getUint32(7, Endian.little), 0); // pad
+      expect(bd.getUint32(5, Endian.little), epoch);
+      expect(bd.getUint16(9, Endian.little), 0); // subsec (whole-second alarm)
+      // Trailing 12 bytes are the haptic pattern (default buzz).
+      expect(f.inner.sublist(11, 23), kDefaultAlarmHaptics);
     });
 
     test('SET_ALARM is NOT in dangerousCmds (normal user action)', () {

--- a/test/whoop_protocol_update_test.dart
+++ b/test/whoop_protocol_update_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:openstrap_protocol/openstrap_protocol.dart';
 import 'package:test/test.dart';
 
@@ -30,6 +32,72 @@ void main() {
       final frame = parseFrame(cmdGetHelloModern(0x01))!;
       expect(frame.valid, isTrue);
       expect(frame.inner, [0x23, 0x01, 0x91, 0x01]);
+    });
+
+    // Export reachability: these are resolved via the public
+    // package:openstrap_protocol/openstrap_protocol.dart import above.
+    test('cmdGetClock is exported and payloadless (opcode 0x0B)', () {
+      final frame = parseFrame(cmdGetClock(0x05))!;
+      expect(frame.valid, isTrue);
+      // 3-byte inner + 1 byte of /4 frame padding.
+      expect(frame.inner, [0x23, 0x05, 0x0B, 0x00]);
+    });
+
+    test('cmdGetDataRange is exported with a [0x00] payload (opcode 0x22)', () {
+      final frame = parseFrame(cmdGetDataRange(0x06))!;
+      expect(frame.valid, isTrue);
+      expect(frame.inner, [0x23, 0x06, 0x22, 0x00]);
+    });
+
+    test('cmdSetClock builds the WHOOP-exact 8-byte sec+subsec payload', () {
+      // Fixed instant: sec = 0x12345678, millis = 500.
+      // subsec = 500 * 32768 ~/ 1000 = 16384 = 0x4000 (u16 LE, then 2 zero pad).
+      final now =
+          DateTime.fromMillisecondsSinceEpoch(0x12345678 * 1000 + 500);
+      final frame = parseFrame(cmdSetClock(0x09, now: now))!;
+      expect(frame.valid, isTrue);
+      expect(frame.inner, [
+        0x23, 0x09, Cmd.setClock, // header: COMMAND, seq, SET_CLOCK 0x0A
+        0x78, 0x56, 0x34, 0x12, // seconds u32 LE
+        0x00, 0x40, // subsec u16 LE (16384/32768 = 0.5 s)
+        0x00, 0x00, // zero pad — total payload exactly 8 bytes
+        0x00, // 1 byte of /4 frame padding (11-byte inner → 12)
+      ]);
+    });
+
+    test('cmdSetClock subsec stays in u16 range at 999 ms', () {
+      // subsec = 999 * 32768 ~/ 1000 = 32735 = 0x7FDF — never overflows u16.
+      final now = DateTime.fromMillisecondsSinceEpoch(1750000000 * 1000 + 999);
+      final frame = parseFrame(cmdSetClock(0x00, now: now))!;
+      expect(frame.valid, isTrue);
+      // header(3) + 8-byte payload = 11, padded /4 → 12 on the wire.
+      expect(frame.inner.length, 12);
+      expect(frame.inner.sublist(7, 11), [0xDF, 0x7F, 0x00, 0x00]);
+    });
+  });
+
+  group('WHOOP danger surface', () {
+    test('dangerousCmds covers trim, reboot, power-cycle, R21 and fw-load', () {
+      expect(
+        dangerousCmds,
+        containsAll([
+          Cmd.forceTrim,
+          Cmd.rebootStrap,
+          Cmd.powerCycleStrap,
+          Cmd.togglePersistentR21,
+          Cmd.startFirmwareLoad,
+          Cmd.loadFirmwareData,
+          Cmd.processFirmwareImage,
+        ]),
+      );
+      // 0x24 here is a Cmd opcode; PacketType.commandResponse (0x24) is a
+      // separate namespace (inner[0], not inner[2]).
+      expect(Cmd.startFirmwareLoad, 0x24);
+      expect(Cmd.powerCycleStrap, 0x20);
+      // 0x62 is GET_EXTENDED_BATTERY_INFO; there is no 0x63 command (the old
+      // "reset fuel gauge" opcode was a decode artifact and has been removed).
+      expect(Cmd.getExtendedBatteryInfo, 0x62);
+      expect(Cmd.getMaxProtocolVersion, 0x02);
     });
   });
 
@@ -107,6 +175,172 @@ void main() {
       expect(parsed.isOffBody, isTrue);
       expect(parsed.locationRaw, 2);
       expect(parsed.location, GarmentDeviceLocation.bicep);
+    });
+  });
+
+  group('WHOOP on-device alarm', () {
+    // Fixed instant: sec = 0x12345678, millis = 500.
+    // subsec = 500 * 32768 ~/ 1000 = 16384 = 0x4000 (u16 LE).
+    final when = DateTime.fromMillisecondsSinceEpoch(0x12345678 * 1000 + 500);
+
+    test('simple form is [0x01][u32 sec LE][u16 subsec LE]', () {
+      final frame = parseFrame(cmdSetAlarmSimple(0x0A, when))!;
+      expect(frame.valid, isTrue);
+      expect(frame.inner, [
+        0x23, 0x0A, Cmd.setAlarmTime, // COMMAND, seq, SET_ALARM_TIME 0x42
+        0x01, //                         time-only form marker
+        0x78, 0x56, 0x34, 0x12, //       epoch seconds u32 LE
+        0x00, 0x40, //                   sub-seconds u16 LE (16384 = 0.5 s)
+        0x00, 0x00, //                   /4 frame padding (10-byte inner → 12)
+      ]);
+    });
+
+    test('rich form carries the default 12-byte haptic pattern and fires', () {
+      final frame = parseFrame(cmdSetAlarm(0x0B, when))!;
+      expect(frame.valid, isTrue);
+      expect(frame.inner, [
+        0x23, 0x0B, Cmd.setAlarmTime, // COMMAND, seq, SET_ALARM_TIME 0x42
+        0x04, //                         rich-form marker (fires haptics)
+        0x00, //                         alarm slot index (default 0)
+        0x78, 0x56, 0x34, 0x12, //       epoch seconds u32 LE
+        0x00, 0x40, //                   sub-seconds u16 LE
+        47, 152, 0, 0, 0, 0, 0, 0, //    8× waveform effects
+        0, 0, //                         loopControl u16 LE
+        7, //                            overall waveform loop
+        30, //                           duration seconds
+        0x00, //                         /4 frame padding (23-byte inner → 24)
+      ]);
+      // The default pattern exported for callers matches what we serialise.
+      expect(kDefaultAlarmHaptics,
+          [47, 152, 0, 0, 0, 0, 0, 0, 0, 0, 7, 30]);
+    });
+
+    test('rich form honours a custom index and haptic pattern', () {
+      final custom = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+      final frame =
+          parseFrame(cmdSetAlarm(0x00, when, index: 3, hapticPattern: custom))!;
+      expect(frame.inner.sublist(3, 11),
+          [0x04, 0x03, 0x78, 0x56, 0x34, 0x12, 0x00, 0x40]);
+      expect(frame.inner.sublist(11, 23), custom);
+    });
+
+    test('rich form rejects a wrong-length haptic pattern', () {
+      expect(() => cmdSetAlarm(0x00, when, hapticPattern: const [1, 2, 3]),
+          throwsArgumentError);
+    });
+
+    test('run alarm rev1 is [0x01], rev2 is [0x02][mode] (opcode 0x44)', () {
+      final rev1 = parseFrame(cmdRunAlarm(0x01))!;
+      expect(rev1.inner, [0x23, 0x01, Cmd.runAlarm, 0x01]);
+      final rev2 = parseFrame(cmdRunAlarm(0x02, mode: 0x05))!;
+      expect(rev2.inner.sublist(0, 5), [0x23, 0x02, Cmd.runAlarm, 0x02, 0x05]);
+    });
+
+    test('disable alarm rev1 is [0x01], rev2 is [0x02][0xFF] (opcode 0x45)', () {
+      final rev1 = parseFrame(cmdDisableAlarm(0x03))!;
+      expect(rev1.inner, [0x23, 0x03, Cmd.disableAlarm, 0x01]);
+      final rev2 = parseFrame(cmdDisableAlarm(0x04, revision: 2))!;
+      expect(
+          rev2.inner.sublist(0, 5), [0x23, 0x04, Cmd.disableAlarm, 0x02, 0xFF]);
+    });
+  });
+
+  group('WHOOP event ids', () {
+    test('newly confirmed ids resolve to their names', () {
+      expect(EventId.boot, 15);
+      expect(EventId.setRtc, 16);
+      expect(EventId.hapticsFired, 60);
+      expect(EventId.name(EventId.boot), 'BOOT');
+      expect(EventId.name(EventId.setRtc), 'SET_RTC');
+      expect(EventId.name(EventId.temperatureLevel), 'TEMPERATURE_LEVEL');
+      expect(EventId.name(EventId.trimAllData), 'TRIM_ALL_DATA');
+      expect(EventId.name(EventId.trimAllDataEnded), 'TRIM_ALL_DATA_ENDED');
+      expect(EventId.name(EventId.ch1Saturation), 'CH1_SATURATION_DETECTED');
+      expect(EventId.name(EventId.ch2Saturation), 'CH2_SATURATION_DETECTED');
+      expect(EventId.name(EventId.accelSaturation),
+          'ACCELEROMETER_SATURATION_DETECTED');
+      expect(EventId.name(EventId.rawDataCollectionOn), 'RAW_DATA_COLLECTION_ON');
+      expect(
+          EventId.name(EventId.rawDataCollectionOff), 'RAW_DATA_COLLECTION_OFF');
+      expect(EventId.name(EventId.strapDrivenAlarmSet), 'STRAP_DRIVEN_ALARM_SET');
+      expect(EventId.name(EventId.strapDrivenAlarmExecuted),
+          'STRAP_DRIVEN_ALARM_EXECUTED');
+      expect(EventId.name(EventId.appDrivenAlarmExecuted),
+          'APP_DRIVEN_ALARM_EXECUTED');
+      expect(EventId.name(EventId.strapDrivenAlarmDisabled),
+          'STRAP_DRIVEN_ALARM_DISABLED');
+    });
+
+    test('parseEvent decodes id@2, ts@4, subsec@8 and body@12', () {
+      // 0x30 EVENT: eid=16 (SET_RTC) @2, ts=0x12345678 @4, subsec=0x4000 @8,
+      // pad @10..12, body [0xAA,0xBB] @12.
+      final inner = Uint8List.fromList([
+        0x30, 0x00, //             packet type EVENT, seq
+        0x10, 0x00, //             event id u16 LE = 16
+        0x78, 0x56, 0x34, 0x12, // ts seconds u32 LE
+        0x00, 0x40, //             sub-seconds u16 LE
+        0x00, 0x00, //             pad to the body offset
+        0xAA, 0xBB, //             event body
+      ]);
+      final e = parseEvent(inner)!;
+      expect(e.eventId, EventId.setRtc);
+      expect(e.name, 'SET_RTC');
+      expect(e.tsEpoch, 0x12345678);
+      expect(e.tsSubsec, 0x4000);
+      expect(e.body, [0xAA, 0xBB]);
+    });
+  });
+
+  group('WHOOP historical record versions', () {
+    // Build a 96-byte record inner with a plausible ~1 g gravity vector and a
+    // given HR at [hrOffset].
+    Uint8List record(int version, {required int hr, required int hrOffset,
+        double gz = 1.0}) {
+      final b = Uint8List(96);
+      b[0] = 0x2f; // packet type (historical)
+      b[1] = version;
+      final bd = ByteData.sublistView(b);
+      bd.setUint32(3, 0x0A0B0C0D, Endian.little); // counter
+      bd.setUint32(7, 0x11223344, Endian.little); // ts seconds
+      bd.setUint16(11, 0x0102, Endian.little); // subsec
+      b[hrOffset] = hr;
+      bd.setFloat32(36, 0.0, Endian.little); // gravity x
+      bd.setFloat32(40, 0.0, Endian.little); // gravity y
+      bd.setFloat32(44, gz, Endian.little); // gravity z
+      return b;
+    }
+
+    test('v18 reads HR at offset 14', () {
+      final r = parseR24(record(18, hr: 60, hrOffset: 14))!;
+      expect(r.histVersion, 18);
+      expect(r.hr, 60);
+      expect(r.counter, 0x0A0B0C0D);
+      expect(r.tsEpoch, 0x11223344);
+      expect(r.tsSubsec, 0x0102);
+    });
+
+    test('v24 still reads HR at offset 17 (trusted, un-gated)', () {
+      // HR=0 (off-wrist) still decodes on the trusted path — no plausibility gate.
+      final r = parseR24(record(24, hr: 0, hrOffset: 17))!;
+      expect(r.histVersion, 24);
+      expect(r.hr, 0);
+    });
+
+    test('unknown version decodes via v24 map when physiologically plausible',
+        () {
+      final r = parseR24(record(200, hr: 72, hrOffset: 17))!;
+      expect(r.histVersion, 200);
+      expect(r.hr, 72);
+    });
+
+    test('best-effort decode is rejected when HR is implausible', () {
+      // v18 with HR below the human floor → null (only HR offset is confirmed).
+      expect(parseR24(record(18, hr: 5, hrOffset: 14)), isNull);
+    });
+
+    test('best-effort decode is rejected when gravity is implausible', () {
+      // Unknown version with near-zero gravity magnitude → null.
+      expect(parseR24(record(200, hr: 72, hrOffset: 17, gz: 0.05)), isNull);
     });
   });
 }

--- a/test/whoop_protocol_update_test.dart
+++ b/test/whoop_protocol_update_test.dart
@@ -3,6 +3,23 @@ import 'package:test/test.dart';
 
 void main() {
   group('WHOOP command builders', () {
+    test('history result success uses cmd 0x17 + success byte + token', () {
+      final frame = parseFrame(
+        buildHistoryResultOk(0x21, hexToBytes('1122334455667788')),
+      )!;
+      expect(frame.valid, isTrue);
+      expect(
+        frame.inner,
+        [0x23, 0x21, 0x17, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+      );
+    });
+
+    test('history result failure uses cmd 0x17 + failure byte', () {
+      final frame = parseFrame(buildHistoryResultFail(0x22))!;
+      expect(frame.valid, isTrue);
+      expect(frame.inner, [0x23, 0x22, 0x17, 0x00]);
+    });
+
     test('enter high-frequency sync uses revision 2 + little-endian u16s', () {
       final frame = parseFrame(
         cmdEnterHighFreqSync(0x12, intervalSeconds: 300, durationSeconds: 900),
@@ -107,6 +124,37 @@ void main() {
       expect(parsed.isOffBody, isTrue);
       expect(parsed.locationRaw, 2);
       expect(parsed.location, GarmentDeviceLocation.bicep);
+    });
+  });
+
+  group('WHOOP event decode', () {
+    test('high-frequency prompt/enabled/disabled events are modeled', () {
+      final prompt = parseEvent(hexToBytes('3001600001020304'))!;
+      final enabled = parseEvent(hexToBytes('3001610001020304'))!;
+      final disabled = parseEvent(hexToBytes('3001620001020304'))!;
+
+      expect(prompt.eventId, EventId.highFreqSyncPrompt);
+      expect(prompt.name, 'HIGH_FREQ_SYNC_PROMPT');
+      expect(prompt.decoded['high_freq_sync'], 'prompt');
+
+      expect(enabled.eventId, EventId.highFreqSyncEnabled);
+      expect(enabled.name, 'HIGH_FREQ_SYNC_ENABLED');
+      expect(enabled.decoded['high_freq_sync'], 'enabled');
+
+      expect(disabled.eventId, EventId.highFreqSyncDisabled);
+      expect(disabled.name, 'HIGH_FREQ_SYNC_DISABLED');
+      expect(disabled.decoded['high_freq_sync'], 'disabled');
+    });
+  });
+
+  group('WHOOP metadata decode', () {
+    test('history end exposes expected packet count and ack token', () {
+      final m = parseMetadata(
+        hexToBytes('3100020000000000002a0000001122334455667788'),
+      )!;
+      expect(m.sub, SyncMeta.historyEnd);
+      expect(m.expectedPacketCount, 42);
+      expect(m.token, hexToBytes('1122334455667788'));
     });
   });
 }

--- a/ts/hello.ts
+++ b/ts/hello.ts
@@ -1,1 +1,0 @@
-console.log("hello")


### PR DESCRIPTION
## Summary
Protocol additions and fixes, all hardware-verified, tests green (39 + 2934-case parity).

- **Alarm** — real `SET_ALARM` payloads: a 7-byte simple form and the 20-byte haptic form that actually fires (the previous short form ACKed but never buzzed); adds `RUN_ALARM` (0x44) and `DISABLE_ALARM` (0x45).
- **Events** — new IDs 15–60 (SET_RTC, trim markers, CH/accel saturation, strap/app alarm set·executed·disabled, haptics-fired) + `name()` mappings; `parseEvent` now decodes ts sub-seconds and the event body offset.
- **Records** — v18 HR-offset support and a physiological-plausibility fallback so an unrecognized record version degrades to a validated best-effort instead of corrupt data.
- **Commands** — new `cmdSetClock`; export the previously-unreachable `cmdGetClock`/`cmdGetDataRange`; add `getMaxProtocolVersion` + `powerCycleStrap`; correct the danger-command set.
- Delete the empty `ts/hello.ts` stub.