### PR TITLE
fix a few decode bugs + fix the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,113 @@
 # OpenStrap protocol
 
-These are the decoders. You hand them an already-unwrapped chunk of bytes from the band,
-they hand you back a record with named fields. That's the whole job. No Bluetooth, no
-CRCs, no reassembly, just bytes turning into meaning. The
-[backend](https://github.com/OpenStrap/backend) calls these server-side to make sense of
-the frames your phone uploads.
+Pure Dart, zero runtime deps. You hand it an already-unwrapped chunk of bytes from the
+band, it hands you back a record with named fields, or a decoded command/event. That's
+the whole job.
 
-It's small because it's only the part the production stack actually runs in TypeScript.
-If you want the full picture, the byte-by-byte map, the framing, the command set, the sync
-handshake, that all lives in the [research repo](https://github.com/OpenStrap/research)
-in `PROTOCOL.md`. This is the working subset, ported and trimmed.
+This isn't backend-side anymore — the app ([edge](https://github.com/OpenStrap/edge))
+depends on this package directly and calls it on-device. There's no cloud, no upload, no
+server that ever sees your raw bytes.
 
 > Not affiliated with WHOOP. This is for reading your own band's data.
 
+## What's actually in here
+
+- `records.dart` — the record decoders (`R24`, `parseR24`, and the firmware-aware
+  fallback chain for older/short frames — see below).
+- `live.dart` — the live/high-rate stuff: R10, the 0x28 compact-HR stream, the 0x33 IMU
+  stream, RR-interval extraction.
+- `framing.dart` — the actual byte-level framing: `0xAA` start-of-frame, CRC8 length
+  check, CRC32 payload check, the length-based reassembler. This lives HERE, not
+  upstream — a previous version of this README claimed there was no framing code in this
+  package at all, which stopped being true a while ago.
+- `crc.dart` — crc8/crc32.
+- `commands.dart` / `control.dart` — command builders (SET_CLOCK, alarms, sync commands,
+  etc.) and the control-plane decoders (HELLO, events, command responses, metadata/sync
+  markers).
+- `constants.dart` — the GATT UUIDs, opcode tables, event IDs.
+
 ## The one record that matters most
 
-`parse_r24` decodes the 1 Hz historical record, which is the bulk of what comes off the
-band during a sync, one of these per second of wear. Give it the inner payload (89 bytes
-or more) and you get back this, or `null` if it's too short:
+`parseR24` decodes the 1 Hz historical record — the bulk of what comes off the band
+during a sync, one of these per second of wear. Give it the inner payload and you get
+back an `R24`, or `null` if it doesn't decode:
 
-```ts
-interface R24 {
-  ts_epoch: number;          // [7:11]   unix seconds
-  ts_subsec: number;         // [11:13]
-  counter: number;           // [3:7]    goes up by one each record
-  hr: number;                // [17]     heart rate, 0 means no reading
-  spo2: number;              // [72]     blood oxygen %
-  skin_temp_c: number;       // [70]/4   skin temperature in °C
-  resting_hr: number;        // [88]     a held baseline, not your live HR
-  accel_g: [number, number, number]; // [36:48]  three little-endian floats, in g
-  raw_tail: string;          // [13:]    the whole payload as hex, kept untouched
+```dart
+class R24 {
+  final int histVersion;     // layout version byte @ inner[1]
+  final int tsEpoch;         // unix seconds @ inner[7:11]
+  final int tsSubsec;        // sub-seconds @ inner[11:13]
+  final int counter;         // record counter @ inner[3:7]
+  final int hr;               // heart rate bpm @ inner[17] — 0 means off-wrist, not bradycardia
+  final int rrCount;          // 0-4 beat-to-beat intervals this second
+  final List<int> rrIntervalsMs;
+  final int ppgGreen;         // raw green-LED PPG ADC @ inner[29]
+  final int ppgRedIr;         // raw red/IR-LED PPG ADC @ inner[31]
+  final List<double> accelG;  // 3x float32 gravity vector @ inner[36:48]
+  final int skinContact;      // contact QUALITY @ inner[51] — NOT wear/on-wrist state
+  final int spo2RedRaw;       // raw red-channel ADC @ inner[64]
+  final int spo2IrRaw;        // raw IR-channel ADC @ inner[66]
+  final int skinTempRaw;      // raw skin-temp ADC @ inner[68]
+  final int ambientRaw;       // raw ambient-light ADC @ inner[70]
+  // ...
 }
 ```
 
-```ts
-import { parse_r24 } from 'openstrap-protocol/ts/records'
-const sample = parse_r24(inner)
-if (sample) console.log(sample.hr, new Date(sample.ts_epoch * 1000))
+```dart
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+
+final sample = parseR24(inner);
+if (sample != null) {
+  print('${sample.hr} bpm at ${DateTime.fromMillisecondsSinceEpoch(sample.tsEpoch * 1000)}');
+}
 ```
 
-## What I'm sure of and what I'm not
+All the SpO2/skin-temp/ambient fields are **raw relative ADC counts**, not calibrated
+units — there's no absolute % or °C conversion here, and there shouldn't be one anywhere
+downstream either. `skinContact` is a contact-quality signal, not a wear-state flag —
+don't use it to decide if the band is on the wrist.
 
-I want to be honest about this because it's the difference between a decoder you can trust
-and one that quietly lies to you.
+Historical records don't all ship the same layout. `parseR24` decodes v24/v12 verbatim;
+`FirmwareAwareR24Decoder` (chain-of-responsibility) is the one to actually reach for on
+real devices — it tries the validated 89-byte layout first, then falls back to a
+72-byte-floor layout (the true minimum every field it reads actually needs) for older
+firmware that sends shorter frames, remembering per-record-version which strategy worked.
+Other versions (v7/v9/v18/unknown) route through the v24 field map at a per-version HR
+offset, gated by a physiological-plausibility check (HR 25-230bpm AND accel magnitude²
+0.25-3.24) so an implausible unknown-version record doesn't get decoded as if it were
+real.
 
-The header and the heart rate? Solid. I've watched `hr` at byte `[17]` track the live
-stream within a beat or two on a band I was actually wearing. That one's real.
+## What's verified and what's a plausible read
 
-Everything after the header is a best guess. The band relays most of this record straight
-to WHOOP's cloud without decoding it, so there's no clean reference to check against. The
-accelerometer at `[36:48]`, the temperature at `[70]`, the SpO₂ at `[72]`, the resting HR
-at `[88]`, I worked those out by watching how the bytes moved against things I could
-verify: acceleration sits around 1g when the band is still, the temperature byte climbs
-when you put the band on, SpO₂ parks in the low 90s at rest. Plausible. Consistent. Not
-confirmed. They're labelled empirical in the code and you should read them that way.
+The header and heart rate are solid — `hr` at `inner[17]` has been checked against a live
+stream on a real worn band.
 
-That's also why every record keeps its `raw_tail`: the full payload as hex, nothing
-dropped. If someone someday nails down what byte 68 actually is, we re-decode every record
-we ever stored and the old data just gets better. Nothing is lost to a bad early guess.
-
-## Where the bytes get unwrapped
-
-You'll notice there's no frame parsing in here, no CRC checks, no `0xAA` handling. By the
-time `parse_r24` runs, someone upstream has already pulled the inner payload out of the
-frame and confirmed it's intact. That work lives in the clients: the Flutter app
-([edge](https://github.com/OpenStrap/edge), in `lib/protocol/`) and the Python reference
-client ([research](https://github.com/OpenStrap/research)) each carry their own
-reassembler. `PROTOCOL.md` documents the envelope and the packet types if you need to
-build one.
+The PPG/accel/optical fields further into the record are a real, working decode (this
+whole map is checked against a frozen TypeScript oracle — `decode_parity_cases.json`,
+2934 real captured cases, all passing) — but "decodes correctly" and "means something
+diagnostic" aren't the same claim. SpO2/skin-temp/ambient are raw ADC counts with no
+calibration curve; treat them as relative-only, ever.
 
 ## Build it
 
+Pure Dart, no Flutter dependency:
+
 ```bash
-npx tsc                          # compile ts/ to dist/
-npx tsx ts/test_decoder.ts       # run it against a fixture capture
+dart pub get
+dart test          # 70 tests, incl. the 2934-case TS-parity suite
 ```
+
+Run tests from the repo root — the parity fixture (`decode_parity_cases.json`) is
+resolved relative to it.
 
 ## Adding or fixing a decoder
 
-If you've figured out a field, or want to add `parse_r10` or any of the others on the TS
-side, write a function that takes the inner `Uint8Array` and returns a typed object or
-`null`. Read multi-byte values little-endian with a `DataView`. Label every field as
-verified or empirical, and be honest about which it is, a confident wrong label is worse
-than no label. Keep the untouched tail around. And if you've actually pinned down one of
-the empirical fields with real evidence, that's exactly the kind of thing I want in an
-issue or a PR.
+If you've figured out a field or want to add a new record type: read multi-byte values
+little-endian, return `null` (never throw) on malformed/short input, and label anything
+you're not 100% sure of as empirical, not verified — a confident wrong label is worse than
+an honest "not sure." If you're touching `records.dart`'s multi-version decode chain,
+check `FirmwareAwareR24Decoder` first — chances are your case fits the existing fallback
+shape rather than needing a new one.
+
+Cross-checking against `_external/noop` (a separate open WHOOP reference project,
+PolyForm Noncommercial license) for facts/techniques is fine; copying its code is not.

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -184,7 +184,10 @@ RealtimeHr? parseRealtimeHr(Uint8List inner) {
   final hr = inner[8];
   if (hr < 1 || hr > 250) return null;
   final rr = <int>[];
-  final n = inner[9];
+  // a 9-byte packet has ts+hr but nothing past it - inner[9] (rr_count) would
+  // be one byte out of bounds. no rr_count byte just means no RR intervals,
+  // not "reject this decode" (copilot review caught this, real bug).
+  final n = inner.length > 9 ? inner[9] : 0;
   if (n > 0 && inner.length >= 12) {
     final v = u16(inner, 10);
     if (v >= 200 && v <= 2500) rr.add(v);
@@ -623,6 +626,7 @@ Decoded _decodeDataRecord(Uint8List inner) {
     if (hr != null) {
       return Decoded('realtime_hr', {
         'rec_type': recType,
+        'ts_epoch': hr.tsRaw,
         'hr': hr.hrBpm,
         'hr_precise': hr.hrPrecise,
         'rr_ms': hr.rrMs,

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -172,25 +172,29 @@ class RealtimeHr {
   RealtimeHr(this.hrBpm, this.hrPrecise, this.rrMs, this.wearing, this.tsRaw);
 }
 
-/// 0x28 HR payload: [0:4]ts [4:6]HR u16/256 [6]rr_count [7:9]rr1 [9:11]rr2 [15]wearing.
-RealtimeHr? parseRealtimeHr(Uint8List body) {
-  if (body.length < 7) return null;
-  final ts = u32(body, 0);
-  final hrPrecise = u16(body, 4) / 256.0;
-  final hr = hrPrecise.round();
+// was reading ts/hr one byte off from the real layout (used to slice off 3
+// header bytes before calling this, which put hr at the wrong spot). checked
+// against live.dart's realtimeRr/decodeRecord which are already verified
+// against the ts parity oracle, and lines up like this instead:
+// ts@2 (u32), hr@8 (u8, not u16/256), rr_count@9, rr1@10, rr2@12, wearing@18.
+// so this now just takes the whole inner frame, not a pre-sliced body.
+RealtimeHr? parseRealtimeHr(Uint8List inner) {
+  if (inner.length < 9) return null;
+  final ts = u32(inner, 2);
+  final hr = inner[8];
   if (hr < 1 || hr > 250) return null;
   final rr = <int>[];
-  final n = body[6];
-  if (n > 0 && body.length >= 9) {
-    final v = u16(body, 7);
+  final n = inner[9];
+  if (n > 0 && inner.length >= 12) {
+    final v = u16(inner, 10);
     if (v >= 200 && v <= 2500) rr.add(v);
   }
-  if (n > 1 && body.length >= 11) {
-    final v = u16(body, 9);
+  if (n > 1 && inner.length >= 14) {
+    final v = u16(inner, 12);
     if (v >= 200 && v <= 2500) rr.add(v);
   }
-  final wearing = body.length > 15 ? body[15] == 1 : true;
-  return RealtimeHr(hr, _round(hrPrecise, 2), rr, wearing, ts);
+  final wearing = inner.length > 18 ? inner[18] == 1 : true;
+  return RealtimeHr(hr, hr.toDouble(), rr, wearing, ts);
 }
 
 RealtimeHrV2? parseRealtimeHrV2(Uint8List body) {
@@ -615,9 +619,7 @@ Decoded _decodeDataRecord(Uint8List inner) {
   final recType = inner.length > 1 ? inner[1] : -1;
   // Compact realtime stream (small packet).
   if (inner.length < 64) {
-    final body =
-        inner.length > 3 ? Uint8List.sublistView(inner, 3) : Uint8List(0);
-    final hr = parseRealtimeHr(body);
+    final hr = parseRealtimeHr(inner);
     if (hr != null) {
       return Decoded('realtime_hr', {
         'rec_type': recType,

--- a/lib/src/framing.dart
+++ b/lib/src/framing.dart
@@ -59,6 +59,10 @@ Frame? parseFrame(Uint8List raw) {
   if (raw.length < 8 || raw[0] != sof) return null;
   final bd = raw.buffer.asByteData(raw.offsetInBytes, raw.length);
   final declared = bd.getUint16(1, Endian.little);
+  // declared has to be at least 4 (the trailing crc32) or the inner slice
+  // math below goes negative and sublistView throws instead of us just
+  // saying "not a valid frame" like the length checks above already do.
+  if (declared < 4) return null;
   final crc8Ok = raw[3] == crc8(Uint8List.sublistView(raw, 1, 3));
   const innerStart = 4;
   final total = 4 + declared;

--- a/lib/src/records.dart
+++ b/lib/src/records.dart
@@ -233,6 +233,11 @@ const int _legacyMinLength = 89;
 /// [FirmwareAwareR24Decoder] AFTER the legacy 89-byte attempt has failed —
 /// never used as the default, so devices matching the original validated
 /// shape are completely unaffected.
+// note: edge's live BLE path pads 88-byte v12 frames up to 89 before it ever
+// calls the decoder now, so this tier doesn't actually get hit for that
+// anymore - but db.dart / substrate.dart's raw-hex re-derive paths see the
+// un-padded bytes directly and still need it. don't remove this thinking
+// it's dead, it's just dead for the one case it was originally written for.
 const int _shortFrameMinLength = 72;
 
 /// Decode the WHOOP 4 v24 field map with a parameterised HR offset. When

--- a/test/parity_test.dart
+++ b/test/parity_test.dart
@@ -49,8 +49,12 @@ String? _diff(dynamic actual, dynamic expected, String path) {
       if (d != null) return d;
     }
     // Ensure actual carries no extra keys that expected lacks (1:1 shape).
+    // xs/ys/zs got added to ImuFrame.toMap() for raw-axis diagnostics after
+    // these fixtures were generated from the TS oracle, so they're not in
+    // `expected` here - allow just those, still fail on anything else new.
+    const allowedExtras = {'xs', 'ys', 'zs'};
     for (final k in actual.keys) {
-      if (!expected.containsKey(k)) {
+      if (!expected.containsKey(k) && !allowedExtras.contains(k)) {
         return 'at $path.$k: unexpected extra key (value ${actual[k]})';
       }
     }

--- a/test/whoop_protocol_update_test.dart
+++ b/test/whoop_protocol_update_test.dart
@@ -497,9 +497,30 @@ void main() {
 
       final decoded = decodeFrame(Frame(b, true, true));
       expect(decoded.kind, 'realtime_hr');
+      // copilot review flagged this - the whole point of the bug was
+      // corrupted timestamps, and this test never actually checked one.
+      expect(decoded.fields['ts_epoch'], 1780840486);
       expect(decoded.fields['hr'], 65);
       expect(decoded.fields['rr_ms'], [900]);
       expect(decoded.fields['wearing'], isTrue);
+    });
+
+    // copilot review also caught a real one: a 9-byte packet (ts+hr, no
+    // rr_count byte at all) would read inner[9] out of bounds and throw
+    // instead of decoding. fixed to treat a missing rr_count byte as "no RR
+    // intervals" rather than crashing.
+    test('a 9-byte packet (ts+hr only, no rr_count byte) decodes instead of throwing', () {
+      final b = Uint8List(9);
+      final bd = b.buffer.asByteData();
+      b[0] = 0x28;
+      bd.setUint32(2, 1780840486, Endian.little);
+      b[8] = 65;
+
+      final decoded = decodeFrame(Frame(b, true, true));
+      expect(decoded.kind, 'realtime_hr');
+      expect(decoded.fields['ts_epoch'], 1780840486);
+      expect(decoded.fields['hr'], 65);
+      expect(decoded.fields['rr_ms'], isEmpty);
     });
   });
 }

--- a/test/whoop_protocol_update_test.dart
+++ b/test/whoop_protocol_update_test.dart
@@ -479,4 +479,27 @@ void main() {
       expect(m.token, hexToBytes('1122334455667788'));
     });
   });
+
+  group('compact 0x28 realtime HR decode', () {
+    // used to read ts one byte early (off inner[3] instead of inner[2], left
+    // over from a 3-byte header skip) and hr as a fake u16/256 value instead
+    // of the plain byte it actually is - found this against a real capture
+    // where it decoded to some year-2089 garbage timestamp.
+    test('reads ts/hr/rr from the real layout, not shifted by the old header skip', () {
+      final b = Uint8List(20);
+      final bd = b.buffer.asByteData();
+      b[0] = 0x28;
+      bd.setUint32(2, 1780840486, Endian.little); // ts
+      b[8] = 65; // hr
+      b[9] = 1; // rr_count
+      bd.setInt16(10, 900, Endian.little); // rr1
+      b[18] = 1; // wearing
+
+      final decoded = decodeFrame(Frame(b, true, true));
+      expect(decoded.kind, 'realtime_hr');
+      expect(decoded.fields['hr'], 65);
+      expect(decoded.fields['rr_ms'], [900]);
+      expect(decoded.fields['wearing'], isTrue);
+    });
+  });
 }


### PR DESCRIPTION
went through the whole repo looking for bugs, found a couple real ones:

- 0x28 realtime hr decode was reading ts/hr off the wrong bytes (leftover
  3-byte header skip), decoded garbage timestamps on real device data.
  fixed to line up with live.dart's layout, which is already checked
  against the ts parity oracle
- parseFrame could throw a RangeError instead of returning null on a bad
  length byte
- relaxed the parity test's extra-key check for xs/ys/zs (added to
  ImuFrame after the fixtures were frozen, so they were never in there)
- left a note on the short-frame decoder tier explaining why it's not
  actually dead, just dead for the one case (v12) it was written for

also rewrote the readme, it was describing a totally different setup
(backend-side TS decoder, no framing/CRC in this package - both wrong now)

70 tests green. not merging this myself, wanted a look first.