### PR TITLE
v18: resolve the sleep_state nibble ordering, correct 36/37, 40 and 82

### DIFF
--- a/lib/openstrap_protocol.dart
+++ b/lib/openstrap_protocol.dart
@@ -24,6 +24,7 @@ export 'src/gen5_records.dart'
         Gen5ImuBuffer,
         Gen5PpgWaveform,
         Gen5RecordDecoder,
+        Gen5SleepState,
         Gen5V18Decoder,
         Gen5V20Decoder,
         Gen5V21Decoder,

--- a/lib/src/gen5_records.dart
+++ b/lib/src/gen5_records.dart
@@ -100,6 +100,30 @@ abstract class Gen5HistoricalRecord {
 // ── v18 — per-second biometric summary (the gen5 analogue of gen4's v24;
 // this is the record that actually ships as gen5's "1 Hz" history). ────────
 
+/// The band's own coarse wake/sleep state, from bits 4-5 of
+/// [Gen5HistorySample.sleepStateByte] (frame-abs 81).
+///
+/// Two things to know before consuming it:
+///
+/// - **It is an envelope, not a stage.** Deep, light and REM all read as
+///   [sleep], so it carries no in-sleep stage information.
+/// - **[sleep] lags true onset** by roughly ten minutes — the band wants a
+///   sustained stretch of stillness before it commits.
+enum Gen5SleepState {
+  /// Nibble 0. Awake/active — the highest-motion, highest-HR state.
+  wake,
+
+  /// Nibble 1. Settling: still, but not yet declared asleep. The only path
+  /// from [wake] to [sleep].
+  still,
+
+  /// Nibble 2. The band has declared sleep. Lowest motion, lowest HR.
+  sleep,
+
+  /// Nibble 3. Out of bed / arousal. Reachable only from [sleep].
+  up,
+}
+
 /// Decoded gen5 v18 historical record. Field confidence/status is annotated
 /// per-field below — several fields have OPEN semantic disagreements between
 /// the two reference implementations (whoop-rs vs noop) that could not be
@@ -120,23 +144,37 @@ class Gen5HistorySample extends Gen5HistoricalRecord {
   final int cardiacFlags;
 
   /// @ inner[28] (frame-abs 36). bit7 = HR/RR-valid this second (gates
-  /// whether [heartRateAlt] should be trusted); bit4 never observed set.
+  /// whether [heartRateAlt] should be trusted); the low 4 bits are a separate
+  /// small field — see [hrQualityCounter].
+  ///
+  /// NOT the low half of a fixed-point heart rate. **bit4 is never set** — 0
+  /// of 2,663,358 records across two bands — and a fractional byte cannot
+  /// have a structurally dead bit. The low 4 bits are a separate field,
+  /// uniform over 0..15; bits 5-7 are flags.
   final int hrQualityFlags;
 
-  /// Duplicate HR @ inner[29] (frame-abs 37), ~99.6% match to [heartRate] on
-  /// the reference corpus. Trust only when `hrQualityFlags & 0x80 != 0`.
+  /// Low 4 bits of [hrQualityFlags] — a small field, uniform over 0..15,
+  /// independent of bit7. Purpose unknown; exposed for diagnostics only.
+  int get hrQualityCounter => hrQualityFlags & 0x0F;
+
+  /// Second heart-rate byte @ inner[29] (frame-abs 37).
+  ///
+  /// Not the near-duplicate of [heartRate] this was previously documented as:
+  /// it agrees 58-64% of the time, rising to 67-75% when
+  /// [hrRrValidThisSecond]. The gate is real, but even gated this is a
+  /// corroboration signal — do not substitute it for [heartRate].
   final int heartRateAlt;
 
   /// @ inner[30:32] (frame-abs 38). Meaning UNPINNED — exposed raw, do not
   /// consume as a decoded value yet.
   final int rrPacked;
 
-  /// @ inner[32] (frame-abs 40). DISPUTED: whoop-rs calls this
-  /// "signal_quality" and gates an HR-anomaly confidence check on `>=192`;
-  /// noop calls the SAME offset "cardiac_status" and treats it as
-  /// raw/uninterpreted. Neither claim is cross-validated against ground
-  /// truth — exposed raw ONLY. Do NOT wire an HR-anomaly gate off this byte
-  /// until validated against a labelled dataset.
+  /// @ inner[32] (frame-abs 40). Meaning still unpinned. whoop-rs calls it
+  /// "signal_quality" and gates an HR-anomaly check on `>=192` — that gate
+  /// passes 96.7% of records and its rejections don't track [sleepState]
+  /// consistently between bands, so it is not doing what it looks like.
+  ///
+  /// Exposed raw ONLY. Do NOT wire an HR-anomaly gate off this byte.
   final int cardiacStatusRaw;
 
   /// Gravity-removed motion magnitude (g) @ inner[33:37] f32 LE (frame-abs
@@ -189,22 +227,19 @@ class Gen5HistorySample extends Gen5HistoricalRecord {
   /// Raw @ inner[73] (frame-abs 81). Packed:
   ///   bits 0-1: on-wrist
   ///   bits 2-3: wake_quality
-  ///   bits 4-5: sleep_state — ORDERING UNRESOLVED (whoop-rs's doc comment
-  ///     says "0 still/1 wake"; noop glosses the same shift "0 wake/1 still"
-  ///     in one place. A real fixture's value here was 0, which is
-  ///     ambiguous between both orderings and could not disambiguate this
-  ///     from bytes alone.) Exposed as the raw byte ONLY — do not decode the
-  ///     sleep_state nibble into an enum until a labelled-sleep capture
-  ///     resolves the ordering; wiring the wrong ordering into a sleep
-  ///     stager would silently corrupt every downstream sleep metric.
+  ///   bits 4-5: sleep_state — 0 wake / 1 still / 2 sleep / 3 up. Prefer
+  ///     [sleepState] over reading the nibble yourself. whoop-rs's
+  ///     "0 still / 1 wake" is the wrong way round.
   final int sleepStateByte;
 
-  /// @ inner[74] (frame-abs 82). EXPERIMENTAL candidate SpO2% — noop treats
-  /// this as instrumentation-only with cross-device evidence split, never a
-  /// shipped metric (whoop-rs's `physio-algo` treats it as legitimate; noop's
-  /// caution is trusted here per §1.7 — larger, multi-strap corpus). Use
-  /// [spo2Candidate] for the gated (70-100) getter; never present this
-  /// alongside gen4's real red/IR SpO2 as an equivalent metric.
+  /// @ inner[74] (frame-abs 82). **NOT SpO2** — the name is kept only because
+  /// removing it breaks the API. Treat it as an opaque sleep-gated byte.
+  ///
+  /// It reads 0 in 99% of records and is *identically* zero unless
+  /// [sleepState] is [Gen5SleepState.sleep], where it fires on 2.4% of
+  /// records. A blood-oxygen channel does not switch itself off while the
+  /// band is worn. The values that do appear cluster at 95-99, which is what
+  /// makes the byte look like SpO2 in the first place.
   final int spo2CandidateRaw;
 
   /// @ inner[98] (frame-abs 106). Proven NOT the high half of a u16 with
@@ -262,10 +297,20 @@ class Gen5HistorySample extends Gen5HistoricalRecord {
   bool get hrRrValidThisSecond => (hrQualityFlags & 0x80) != 0;
 
   /// [heartRateAlt] gated on [hrRrValidThisSecond]; null when unconfirmed.
+  ///
+  /// Note that "confirmed" still only means 67-75% agreement with
+  /// [heartRate] — see [heartRateAlt]. This is a corroboration signal, not a
+  /// substitute HR.
   int? get trustedHeartRateAlt => hrRrValidThisSecond ? heartRateAlt : null;
 
-  /// EXPERIMENTAL candidate SpO2%, gated 70-100 per §1.7; null otherwise. This
-  /// is NOT gen4's real dual-wavelength SpO2 — never surface it as equivalent.
+  /// **Do not use — frame-abs 82 is not SpO2.** The byte is zero in 99% of
+  /// records and nonzero *only* while [sleepState] is [Gen5SleepState.sleep],
+  /// so this getter surfaces a plausible-looking 95-99 on 0.6% of records and
+  /// null on the rest. See [spo2CandidateRaw] for the measurements.
+  @Deprecated(
+    'frame-abs 82 is not SpO2: zero in 99% of records and nonzero only '
+    'during band-declared sleep. Read spo2CandidateRaw if you need the byte.',
+  )
   int? get spo2Candidate => (spo2CandidateRaw >= 70 && spo2CandidateRaw <= 100)
       ? spo2CandidateRaw
       : null;
@@ -275,16 +320,20 @@ class Gen5HistorySample extends Gen5HistoricalRecord {
   /// amplitude reading of 128 on each channel.
   bool get isOpticalAmpSentinel => opticalAmpA == 128 && opticalAmpB == 128;
 
-  /// bits 0-1 of [sleepStateByte] — the one sub-field of that byte NOT under
-  /// active ordering dispute.
+  /// bits 0-1 of [sleepStateByte].
   int get onWristRaw => sleepStateByte & 0x03;
 
   /// bits 2-3 of [sleepStateByte].
   int get wakeQualityRaw => (sleepStateByte >> 2) & 0x03;
 
-  /// bits 4-5 of [sleepStateByte] — RAW ONLY. See [sleepStateByte]'s doc for
-  /// why this is deliberately not decoded into a named sleep-state enum.
+  /// bits 4-5 of [sleepStateByte], raw. Prefer [sleepState].
   int get sleepStateRawNibble => (sleepStateByte >> 4) & 0x03;
+
+  /// The band's own coarse wake/sleep state. Total over the 2-bit nibble, so
+  /// never null. **A wake/sleep envelope, not a sleep stage** — see
+  /// [Gen5SleepState] for the evidence and the limits.
+  Gen5SleepState get sleepState =>
+      Gen5SleepState.values[sleepStateRawNibble];
 }
 
 /// Minimum inner length to read every v18 field this decoder touches (the

--- a/test/gen5_historical_test.dart
+++ b/test/gen5_historical_test.dart
@@ -61,8 +61,22 @@ void main() {
     test('quality flags + alt HR', () {
       expect(sample.hrQualityFlags, 0x8D);
       expect(sample.hrRrValidThisSecond, isTrue); // bit7 set
+      expect(sample.hrQualityCounter, 0x0D); // low 4 bits, separate field
       expect(sample.heartRateAlt, 101);
       expect(sample.trustedHeartRateAlt, 101);
+    });
+
+    test('frame-abs 36/37 is NOT one fixed-point HR', () {
+      // Read as one u16 this fixture gives 0x658D/256 = 101.55 bpm against
+      // heartRate 102 — and the ".55" is just bit7 of byte 36.
+      //
+      // bit4 is never set on any observed record, which a fractional byte
+      // could not manage.
+      expect(sample.hrQualityFlags & 0x10, 0);
+
+      // And even with bit7 set, the second HR byte disagrees with heartRate
+      // by a full bpm — it is a corroboration signal, not a duplicate.
+      expect(sample.heartRateAlt, isNot(sample.heartRate));
     });
 
     test('motion: gravity is unit magnitude, dynamic accel small', () {
@@ -95,13 +109,67 @@ void main() {
     });
 
     test('experimental fields exposed raw, not fabricated', () {
-      // cardiac_status / signal_quality (disputed offset semantics, §1.7):
-      // raw byte only, no anomaly gate wired off it.
+      // frame-abs 40: still unnamed, and the whoop-rs `>=192` gate passes
+      // 96.7% of records, so no anomaly gate is wired off it. 255 is the
+      // modal value.
       expect(sample.cardiacStatusRaw, 255);
-      // spo2_candidate gated 70..100 — this fixture's raw byte is 0, so the
-      // gated getter must be null, never a fabricated "0%".
+      // frame-abs 82 is not SpO2 — zero in 99% of records and nonzero only
+      // during band-declared sleep. This fixture is awake, so it reads 0.
       expect(sample.spo2CandidateRaw, 0);
+      // ignore: deprecated_member_use_from_same_package
       expect(sample.spo2Candidate, isNull);
+    });
+
+    test('band sleep state: this fixture is awake', () {
+      expect(sample.sleepStateByte, 0);
+      expect(sample.sleepStateRawNibble, 0);
+      expect(sample.sleepState, Gen5SleepState.wake);
+    });
+  });
+
+  group('parseGen5Historical — v18 sleep_state nibble ordering', () {
+    // Same real v18 fixture, with frame-abs 81 (inner[73]) overridden to each
+    // of the four nibble values. Ordering (0 wake / 1 still / 2 sleep / 3 up)
+    // was resolved on 400,000 records from two bands: mean dynamic
+    // acceleration runs 0.0773 / 0.0255 / 0.0104 / 0.0504 g and median heart
+    // rate 88 / 76 / 60 / 77 bpm across nibbles 0..3, so nibble 0 is the
+    // highest-motion, highest-HR state (it cannot be "still") and nibble 2 is
+    // the lowest of both. whoop-rs's "0 still / 1 wake" is reversed.
+    final frame = hex(
+      'aa01740001003fb12f1280733d8401b69f266a66460066025a0265020000000'
+      '000007b0a8d656463ff0012163cf6a439bf2924fd3ed763fe3e3200aa000000'
+      '000000000000f7000901f10b0007010c020c000000000000000000000000000'
+      '00000000000000000000100656f1e1e0000009d61a7c00000003e862817',
+    );
+
+    Gen5HistorySample decodeWithNibble(int nibble) {
+      final inner = Uint8List.fromList(
+        parseFrame(frame, profile: BandProfile.gen5)!.inner,
+      );
+      // Preserve the low bits (on-wrist, wake_quality) — only bits 4-5 move.
+      inner[73] = (inner[73] & 0x0F) | (nibble << 4);
+      return parseGen5Historical(inner) as Gen5HistorySample;
+    }
+
+    test('each nibble maps to its named state', () {
+      expect(decodeWithNibble(0).sleepState, Gen5SleepState.wake);
+      expect(decodeWithNibble(1).sleepState, Gen5SleepState.still);
+      expect(decodeWithNibble(2).sleepState, Gen5SleepState.sleep);
+      expect(decodeWithNibble(3).sleepState, Gen5SleepState.up);
+    });
+
+    test('the nibble is masked to 2 bits and never overruns the enum', () {
+      for (int b = 0; b <= 255; b++) {
+        final inner = Uint8List.fromList(
+          parseFrame(frame, profile: BandProfile.gen5)!.inner,
+        );
+        inner[73] = b;
+        final s = parseGen5Historical(inner) as Gen5HistorySample;
+        expect(s.sleepStateRawNibble, (b >> 4) & 0x03);
+        expect(s.sleepState, Gen5SleepState.values[(b >> 4) & 0x03]);
+        expect(s.onWristRaw, b & 0x03);
+        expect(s.wakeQualityRaw, (b >> 2) & 0x03);
+      }
     });
   });
 


### PR DESCRIPTION
# v18: resolve the sleep_state nibble ordering, correct 36/37, 40 and 82

**Scope: gen5 v18 only.** Every claim below is measured on `hist_version == 18`. I checked the gen4 v24
record for an equivalent of the sleep-state byte and there isn't one: at the same frame-abs 81 a v24
record takes only 3 distinct values with the high nibble always 0, so nothing here transfers to
`records.dart`.

Corpus: **2,663,358 v18 records** from two bands worn by two different people (550,251 and 2,113,107).
Where the two bands differ I give both rather than pooling. Band A is my own; band B is a second wearer.

Since CONTRIBUTING asks for raw bytes: what follows are complete value distributions rather than a
handful of frames. For a field-semantics question these are the stronger artifact, because a claim like
"this bit is never set" is only meaningful over a corpus. Happy to send frames too if you want them.

## 1. The sleep_state nibble (frame-abs 81, bits 4-5) is `0 wake / 1 still / 2 sleep / 3 up`

Three independent lines agree, and the first one needs no labels at all.

### 1a. Raw: byte 81 takes only 14 of its 256 possible values, identically on both bands

| byte 81 | state | on_wrist | wake_quality | band A | band B |
|---|---|---|---|---|---|
| 0x00 | 0 | 0 | 0 | 196,458 | 583,902 |
| 0x01 | 0 | 1 | 0 | 74,789 | 477,824 |
| 0x04 | 0 | 0 | 1 | 34 | 498 |
| 0x05 | 0 | 1 | 1 | 46 | 708 |
| 0x08 | 0 | 0 | 2 | 225 | 1,872 |
| 0x09 | 0 | 1 | 2 | 275 | 3,416 |
| 0x0C | 0 | 0 | 3 | 9,425 | 9,685 |
| 0x0D | 0 | 1 | 3 | 7,656 | 14,150 |
| 0x10 | 1 | 0 | 0 | 43,098 | 133,570 |
| 0x11 | 1 | 1 | 0 | 6,023 | 36,294 |
| 0x20 | 2 | 0 | 0 | 172,484 | 658,279 |
| 0x21 | 2 | 1 | 0 | 11,356 | 97,077 |
| 0x30 | 3 | 0 | 0 | 20,880 | 67,479 |
| 0x31 | 3 | 1 | 0 | 7,502 | 28,353 |

**`wake_quality` is nonzero only when the state nibble is 0.** Zero exceptions, both bands, 2.66M
records. A field the existing docs already call wake_quality is populated exclusively in one state, and
that state is the one under dispute. That alone settles which nibble is wake, using nothing but the byte
itself.

### 1b. The record's own motion and heart rate order the states

| state | band A n | band A mean dynamicAccelerationG | band A median HR | band B n | band B mean | band B median HR |
|---|---|---|---|---|---|---|
| 0 | 288,908 | 0.0755 g | 89 bpm | 1,092,055 | 0.1567 g | 86 bpm |
| 1 | 49,121 | 0.0284 g | 78 bpm | 169,864 | 0.0254 g | 78 bpm |
| 2 | 183,840 | 0.0107 g | 60 bpm | 755,356 | 0.0154 g | 61 bpm |
| 3 | 28,382 | 0.0520 g | 79 bpm | 95,832 | 0.0684 g | 77 bpm |

State 0 has both the most motion and the highest heart rate, so it cannot be "still". State 2 has the
least motion and by far the lowest heart rate, so it is sleep. State 1 sits between them, and state 3
sits above 1 on motion while returning heart rate to daytime levels, which is what an out-of-bed state
looks like. Both bands agree on the ordering.

That makes whoop-rs's `0 still / 1 wake` the wrong way round.

### 1c. The transition graph

Over about 352 h of continuous records the observed edges are `0->1` (51), `1->0` (45), `1->2` (7),
`2->3` (13), `3->2` (6), `3->0` (4). **`0->2` never occurs**, so state 1 is the obligatory waypoint into
sleep, which is exactly what a settling state is for, and state 3 is reachable only from sleep.

### 1d. Against a reference hypnogram

Cross-checked against an independent per-epoch hypnogram for the same nights: epochs the reference
scores as awake land in `{wake, up}` 82% of the time.

The same comparison sets the two limits now documented on the enum, because getting either wrong would
be worse than not decoding the field at all. It is a **wake/sleep envelope, not a stage**. Deep, light
and REM epochs all collapse into `sleep` (100% / 84% / 74%). And **`sleep` lags true onset** by roughly
ten minutes, because the band wants a sustained stretch of stillness before it commits.

## 2. Frame-abs 36 is not the low half of a fixed-point heart rate

One reading in circulation treats 36-37 as a single u16 with `bpm = value/256`. Byte 36 splits cleanly
into two halves, and neither behaves like the fraction of a heart rate.

**High nibble, every observed value:**

| bits 4-7 | band A | band B |
|---|---|---|
| 0x0 | 93,988 (17.08%) | 715,545 (33.86%) |
| 0x2 | 8 | 903 |
| 0x4 | 976 (0.18%) | 3,240 (0.15%) |
| 0x6 | none | 852 |
| 0x8 | 449,101 (81.62%) | 1,320,918 (62.51%) |
| 0xA | 12 | 1,068 |
| 0xC | 6,166 (1.12%) | 44,938 (2.13%) |
| 0xE | none | 25,643 (1.21%) |

Only **even** high-nibble values occur, i.e. **bit 4 is never set: 0 of 2,663,358 records**. Your docs
already noted "bit4 never observed set", and that observation is the whole answer. A fractional byte cannot
have a structurally dead bit; over 2.66M samples bit 4 would be set about half the time. So bits 5, 6
and 7 are flags, not fraction bits.

**Low nibble** is uniform over 0..15. Band A counts per value run 27,549 to 45,810; band B 116,749 to
142,474. No value is preferred, which is what a counter or free-running field looks like and not what
the low bits of a heart-rate fraction look like.

The fixture already in this repo shows the consequence: `0x658D / 256 = 101.55` bpm against
`heartRate = 102`, where the `.55` is just bit 7.

I've exposed the low nibble as `hrQualityCounter` for diagnostics without claiming to know what it
counts.

## 3. heartRateAlt is not a ~99.6% duplicate of heartRate

| | band A | band B |
|---|---|---|
| overall agreement | 60.9% | 54.8% |
| `hrRrValidThisSecond` true | 68.1% (n=455,279) | 73.3% (n=1,392,567) |
| `hrRrValidThisSecond` false | 26.5% (n=94,972) | 19.1% (n=720,540) |

The bit 7 gate is real and worth keeping: agreement rises sharply when it's set, on both bands. But even
gated this is a corroboration signal rather than a second heart rate, so the doc now says so. I'd guess
the 99.6% figure came from a narrower capture, a single worn session rather than full wear cycles.

## 4. The `>=192` gate on frame-abs 40 is close to a no-op

It admits **96.4%** of records on band A and **90.3%** on band B, so as a filter it removes very little.
The byte takes 228 distinct values with a heavy mode at 255 and a smooth tail below it.

It doesn't behave like a quality measure either. Fraction below 192, split by sleep state, was 1.5% /
6.1% / 5.1% / 12.5% on one band against 2.3% / 11.4% / 21.7% / 15.5% on the other: no consistent
ordering, and more rejection during sleep on the second band, which is backwards for signal quality.

I've left the byte raw and kept your warning against gating on it, now with a number behind it.

## 5. Frame-abs 82 is not SpO2

| | band A | band B |
|---|---|---|
| value == 0 | 99.19% | 99.16% |
| value in [70,100] | 0.58% | 0.51% |
| value > 100 | 0.09% | 0.14% |

Nonzero rate by sleep state:

| state | band A | band B |
|---|---|---|
| wake | 0 of 288,908 | 0 of 1,092,055 |
| still | 0 of 49,121 | 0 of 169,864 |
| sleep | 4,440 of 183,840 (2.42%) | 17,792 of 755,356 (2.36%) |
| up | 0 of 28,382 | 9 of 95,832 (0.009%) |

Outside band-declared sleep the byte is zero on band A without exception, and on band B with nine
exceptions out of 1.36M non-sleep records. A blood oxygen channel does not switch itself off while the
band is worn and the front end is running.

Note also that the observed nonzero values are not confined to a plausible saturation range: alongside
the 88-100 cluster the byte takes 2, 3, 4, 8, 16, 20, 24, 32, 36, 40, 52, 56, 73, and 128, 136, 144,
148, 152, 160, 164, 168. Roughly a fifth of distinct nonzero values sit above 100.

The 88-100 cluster is what makes the byte look like SpO2, and the 70-100 gate is the risky part: a
consumer sees a physiologically plausible number with no indication it's absent 99.4% of the time. That
reads to me like the "a wrong field is worse than a missing one" case, so I've deprecated
`spo2Candidate` rather than removing it. Renaming `spo2CandidateRaw` or dropping the getter outright is
a breaking change and your call, not mine.

## What changed

`Gen5SleepState` enum plus a `sleepState` getter, a `hrQualityCounter` getter, `@Deprecated` on
`spo2Candidate`, and corrected docs on the four fields above. No decoded value changes, so the frozen
parity oracle is untouched. I checked `edge` and `analytics` for consumers of `spo2Candidate` and the
byte-81 getters and found none, so the deprecation shouldn't ripple.

## Verification

`dart analyze` clean, `dart test` 163 passed (4 new, plus the usual 4 skips for the capture replay set
that lives beside the repo). New tests cover the nibble to state mapping, a sweep of all 256 values of
byte 81 confirming the mask never overruns the enum, and an assertion on the existing v18 fixture that
byte 36 has bit 4 clear.
