### PR TITLE
gen5: record HELLO revision instead of gating parsing

### DIFF
--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -414,16 +414,15 @@ class Gen5HelloInfo {
 
   /// Parse EXACTLY the response body (no header). Returns null when the body is
   /// shorter than the [semanticBodyLen] the fixed-offset parser needs — a short
-  /// body is a failed/foreign reply, never a partially-filled hello — or when
-  /// the body does not announce hello revision 1, since every offset below is
-  /// revision-1-specific and reading them out of an unknown revision would
-  /// invent an identity rather than decode one.
+  /// body is a failed/foreign reply, never a partially-filled hello. The
+  /// revision byte is recorded in [helloRevision] but is not a gate: the
+  /// official parser reads the fixed revision-1 offsets regardless of its
+  /// value.
   ///
   /// Callers should additionally gate on the command-response STATUS byte; a
   /// non-success reply leaves the body unpopulated (see [parseCommandResponse]).
   static Gen5HelloInfo? parse(Uint8List body) {
     if (body.length < semanticBodyLen) return null;
-    if (body[0] != 1) return null; // revision-1 map only
     String cstr(int start, int end) {
       final sb = StringBuffer();
       for (int i = start; i < end && i < body.length; i++) {

--- a/test/gen5_historical_test.dart
+++ b/test/gen5_historical_test.dart
@@ -799,10 +799,17 @@ void main() {
       }
     });
 
-    test('an unknown hello revision is refused, not read at rev-1 offsets', () {
+    test('a non-1 hello revision still parses at the fixed offsets', () {
+      // The revision byte is recorded, not a gate — the official parser reads
+      // the fixed offsets regardless of its value.
       final body = gen5HelloBody();
       body[0] = 2; // some future revision
-      expect(Gen5HelloInfo.parse(body), isNull);
+      final h = Gen5HelloInfo.parse(body)!;
+      expect(h.helloRevision, 2);
+      expect(h.batteryPct, 90);
+      expect(h.serial, '5AG0000001');
+      expect(h.firmwareVersion, '50.40.1.0');
+      expect(h.wristOn, isTrue);
     });
 
     test('an out-of-range battery is omitted, never clamped', () {


### PR DESCRIPTION
## Why

`Gen5HelloInfo.parse` currently rejects a complete WHOOP 5 HELLO response whenever its revision byte is not exactly `1`.

The official WHOOP Android 5.458.0 parser does not use that byte as an equality gate. It records the revision and reads the established fixed-offset HELLO layout through byte 103. Consequently, the current check can discard an otherwise compatible HELLO response and prevent connection readiness after a firmware revision change.

This aligns the parser with the behavior recovered from the official client while retaining a defensive length check for independent implementations.

## What changed

- Removed the `helloRevision == 1` parser requirement.
- Continued exposing the received revision through `helloRevision`.
- Retained the 104-byte minimum-length guard.
- Replaced the old rejection test with a regression test proving that a complete non-1 HELLO body:
  - parses using the established fixed offsets;
  - preserves its revision byte; and
  - retains the expected identity, battery, firmware and wrist-state fields.

## Compatibility and safety

- Revision-1 HELLO responses are unchanged.
- No command, frame or wire encoding changes.
- Short bodies remain rejected.
- Non-success command responses still do not publish HELLO information.
- A non-1 revision is not interpreted using invented offsets; it follows the same fixed-offset behavior as the inspected official parser.

## Evidence

- [Official connection flow: HELLO body and revision treatment](https://github.com/DropTabl/reversing-whoop/blob/main/docs/01-official-connection-flow.md#revision-1-hello-body)
- [HELLO bootstrap evidence: readiness gates](https://github.com/DropTabl/reversing-whoop/blob/main/evidence/2026-07-31-whoop5-hello-bootstrap/manifest.md#gates-versus-state-only-fields)

The inspected official parser records the revision without an explicit `revision == 1` gate and reads the fixed offsets through byte 103.

## Validation

- `dart analyze` — no issues
- `dart test` — 374 passed
- Four external-fixture tests skipped because `whoop_hist.jsonl` is not present beside the repository
- `git diff --check origin/main...HEAD` — clean




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gen5 hello messages with revision values other than 1 are now accepted.
  * The detected revision is retained while message details continue to be decoded consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
