### PR TITLE
decode r11 frames (raw, meaning unconfirmed)

### DIFF
--- a/lib/openstrap_protocol.dart
+++ b/lib/openstrap_protocol.dart
@@ -75,12 +75,14 @@ export 'src/live.dart'
         ImuFrame,
         RealtimeRrResult,
         R10Imu,
+        R11Raw,
         hexToBytes,
         frameAccel,
         frameAccelGen5Live,
         frameAccelForBand,
         realtimeRr,
         decodeR10Imu,
+        decodeR11Raw,
         decodeRecord,
         decodeBatch;
 

--- a/lib/src/live.dart
+++ b/lib/src/live.dart
@@ -539,6 +539,52 @@ R10Imu? decodeR10Imu(String hex) {
   );
 }
 
+/// Raw payload of one live R11 record (inner packet `0x2B`, record type
+/// `0x0B`). The signal's MEANING IS UNCONFIRMED — do not read `channelA`/
+/// `channelB` as accel, gyro, or PPG. What is established (issue #25, and its
+/// self-correction in the same thread): the live region at frame-abs
+/// `[36:436]` is 100 plain int32-LE samples, split into two 50-sample
+/// channels back to back (not one 100-sample stream, and not the
+/// word-swapped-int32 reading first proposed — that reading put a spurious
+/// ~56,700 discontinuity at sample 49 that a plain LE read does not have).
+/// Both accelerometer and cardiac interpretations were checked and ruled out
+/// on real captures; an optical baseline or ambient-light channel remain
+/// plausible but unconfirmed. Effective sample rate is "near 50 Hz per
+/// channel", not confirmed to be exactly 50 Hz.
+class R11Raw {
+  final int ts; // unix seconds (device clock)
+  final List<int> channelA; // 50 raw int32 samples, meaning unconfirmed
+  final List<int> channelB; // 50 raw int32 samples, meaning unconfirmed
+  R11Raw({required this.ts, required this.channelA, required this.channelB});
+}
+
+/// Decode a live R11 record's raw two-channel int32 samples. See [R11Raw] for
+/// what is and is not established about this frame. Returns null if `hex` is
+/// not a long-enough R11 frame.
+R11Raw? decodeR11Raw(String hex) {
+  Uint8List b;
+  try {
+    b = hexToBytes(hex);
+  } catch (_) {
+    return null;
+  }
+  if (b.length < 436 || b[0] != 0x2b || b[1] != 0x0b) return null;
+  final view = b.buffer.asByteData(b.offsetInBytes, b.lengthInBytes);
+  List<int> channel(int off) {
+    final out = <int>[];
+    for (int i = 0; i < 50; i++) {
+      out.add(view.getInt32(off + 4 * i, Endian.little));
+    }
+    return out;
+  }
+
+  return R11Raw(
+    ts: view.getUint32(7, Endian.little),
+    channelA: channel(36),
+    channelB: channel(236),
+  );
+}
+
 /// Decode a batch of hex records, returning all surfaceable samples.
 List<DecodedSample> decodeBatch(List<String> records) {
   final out = <DecodedSample>[];

--- a/lib/src/live.dart
+++ b/lib/src/live.dart
@@ -547,10 +547,13 @@ R10Imu? decodeR10Imu(String hex) {
 /// channels back to back (not one 100-sample stream, and not the
 /// word-swapped-int32 reading first proposed — that reading put a spurious
 /// ~56,700 discontinuity at sample 49 that a plain LE read does not have).
-/// Both accelerometer and cardiac interpretations were checked and ruled out
-/// on real captures; an optical baseline or ambient-light channel remain
-/// plausible but unconfirmed. Effective sample rate is "near 50 Hz per
-/// channel", not confirmed to be exactly 50 Hz.
+/// Accelerometer is ruled out on real captures. A cardiac interpretation is
+/// NOT ruled out: an earlier "not cardiac" call from the same misread was
+/// itself withdrawn once corrected, and a corrected re-check found suggestive
+/// but inconclusive agreement with reference heart rate. Optical baseline or
+/// ambient-light channel remain plausible too. This decoder deliberately
+/// makes no signal-meaning determination. Effective sample rate is "near
+/// 50 Hz per channel", not confirmed to be exactly 50 Hz.
 class R11Raw {
   final int ts; // unix seconds (device clock)
   final List<int> channelA; // 50 raw int32 samples, meaning unconfirmed

--- a/test/r11_test.dart
+++ b/test/r11_test.dart
@@ -1,0 +1,50 @@
+import 'package:openstrap_protocol/openstrap_protocol.dart';
+import 'package:test/test.dart';
+
+// R11 (0x2B/0x0B) container decode. No real R11 capture is checked into this
+// repo, so this pins the parse math against synthetic bytes: 100 int32-LE
+// samples at frame-abs [36:436], split into two 50-sample channels — see
+// R11Raw's doc comment (protocol#25) for why, and for what is NOT claimed
+// about the signal's meaning.
+void main() {
+  test('decodeR11Raw reads two 50-sample int32-LE channels', () {
+    final b = List<int>.filled(436, 0);
+    b[0] = 0x2b;
+    b[1] = 0x0b;
+    // ts u32 LE @ 7
+    const ts = 31624534;
+    b[7] = ts & 0xff;
+    b[8] = (ts >> 8) & 0xff;
+    b[9] = (ts >> 16) & 0xff;
+    b[10] = (ts >> 24) & 0xff;
+
+    void putI32(int off, int v) {
+      b[off] = v & 0xff;
+      b[off + 1] = (v >> 8) & 0xff;
+      b[off + 2] = (v >> 16) & 0xff;
+      b[off + 3] = (v >> 24) & 0xff;
+    }
+
+    // channel A: 150000 + i ; channel B: -2 + i (exercise the sign bit)
+    for (int i = 0; i < 50; i++) {
+      putI32(36 + 4 * i, 150000 + i);
+      putI32(236 + 4 * i, -2 + i);
+    }
+    final hex = b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+
+    final r = decodeR11Raw(hex);
+    expect(r, isNotNull);
+    expect(r!.ts, ts);
+    expect(r.channelA.length, 50);
+    expect(r.channelB.length, 50);
+    expect(r.channelA.first, 150000);
+    expect(r.channelA.last, 150049);
+    expect(r.channelB.first, -2);
+    expect(r.channelB.last, 47);
+  });
+
+  test('decodeR11Raw rejects non-R11 and short input', () {
+    expect(decodeR11Raw('2f1805f1'), isNull); // wrong pkt/rec
+    expect(decodeR11Raw('2b0b'), isNull); // too short
+  });
+}


### PR DESCRIPTION
closes #25 (the r11 part — r10 was already fine, no change needed there)

adds `decodeR11Raw`/`R11Raw` for the live `0x2B`/`0x0B` container. per the issue author's own
follow-up correction in the thread, the region at frame-abs [36:436] is 100 plain int32-LE
samples split into two 50-sample channels back to back — not the word-swapped-int32 reading
first proposed, which put a fake ~56,700 discontinuity at sample 49 that a plain LE read
doesn't have, and which produced a bogus 60/120/180/240 bpm spectral comb that led to a
premature "not cardiac" call. that call is retracted in the thread and this PR doesn't take a
position on what the signal is either — comments say so explicitly (not accel, not confirmed
cardiac, could be optical/ambient). no real captures checked into the repo so the test pins
the parse math against synthetic bytes.

## Summary by Sourcery

Add raw decoding support for live R11 frames without assigning a confirmed meaning to their two-channel signal.

New Features:
- Add support for decoding live R11 records into two raw 50-sample int32 channels and their device timestamp.
- Expose the R11 raw model and decoder through the public protocol library.

Enhancements:
- Document that the decoded R11 signal format is structurally established but its physical meaning and exact sample rate remain unconfirmed.

Tests:
- Add synthetic coverage for R11 channel layout, signed values, timestamps, and invalid or truncated input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding live R11 records.
  * Exposed decoded timestamps and two 50-sample data channels through the public API.
  * Invalid or incomplete R11 frames are safely rejected.

* **Tests**
  * Added coverage for valid R11 decoding and malformed or undersized input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->