### PR TITLE
wire up realtime HR v2 dispatch + r10 hr=0 fix + readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,43 @@
 [![stars](https://img.shields.io/github/stars/OpenStrap/protocol?style=flat&color=e2825f)](https://github.com/OpenStrap/protocol/stargazers)
 [![Donate](https://img.shields.io/badge/donate-BTC%20%2F%20ETH-f7931a)](https://github.com/OpenStrap/edge/blob/main/DONATE.md)
 
-Pure Dart, zero runtime deps. You hand it an already-unwrapped chunk of bytes from the
-band, it hands you back a record with named fields, or a decoded command/event. That's
-the whole job.
+Pure Dart, zero runtime deps, multi-band. You hand it an already-unwrapped chunk of
+bytes from a device — WHOOP 4, WHOOP 5, an Oura ring, or any generic Bluetooth Heart
+Rate Service (0x180D) sensor — it hands you back a record with named fields, or a
+decoded command/event. That's the whole job.
 
 This isn't backend-side anymore — the app ([edge](https://github.com/OpenStrap/edge))
 depends on this package directly and calls it on-device. There's no cloud, no upload, no
 server that ever sees your raw bytes.
 
-> Not affiliated with WHOOP. This is for reading your own band's data.
+> Not affiliated with WHOOP, Oura, or any other device maker. This is for reading your
+> own device's data.
+
+## Part of OpenStrap
+
+This is the byte layer of a three-repo project — reverse-engineered BLE GATT protocols
+in, named records out. Nothing here talks to a server.
+
+- **protocol** (this repo) — bytes ↔ records/frames/commands for WHOOP 4/5, Oura, and
+  generic BLE heart-rate sensors.
+- [analytics](https://github.com/OpenStrap/analytics) — turns those records into
+  metrics: HRV, sleep staging, recovery, strain.
+- [edge](https://github.com/OpenStrap/edge) — the actual app: the Bluetooth connection,
+  storage, sync, UI.
 
 ## What's actually in here
 
-- `records.dart` — the record decoders (`R24`, `parseR24`, and the firmware-aware
-  fallback chain for older/short frames — see below).
+- `band.dart` — the multi-generation device profile (`BandProfile`/`DeviceType`) that
+  keeps framing/records/edge band-agnostic instead of forking per generation.
+- `records.dart` — the WHOOP 4 (gen4) record decoders (`R24`, `parseR24`, and the
+  firmware-aware fallback chain for older/short frames — see below).
+- `gen5_records.dart` — the WHOOP 5 (gen5) record decoders: v18/v20/v21/v26 and the rest
+  of the gen5-specific record map. gen5 is gen4 in a different envelope, not a separate
+  protocol — see `band.dart`'s doc comment for the verified deltas.
+- `oura.dart` — the Oura ring wire format.
+- `hrs.dart` — the Bluetooth SIG Heart Rate Service (`0x180D`) as a pure function, for
+  any standard chest strap or optical armband that implements the spec, not one vendor's
+  device.
 - `live.dart` — the live/high-rate stuff: R10, the 0x28 compact-HR stream, the 0x33 IMU
   stream, RR-interval extraction.
 - `framing.dart` — the actual byte-level framing: `0xAA` start-of-frame, CRC8 length
@@ -30,6 +53,29 @@ server that ever sees your raw bytes.
   etc.) and the control-plane decoders (HELLO, events, command responses, metadata/sync
   markers).
 - `constants.dart` — the GATT UUIDs, opcode tables, event IDs.
+
+## WHOOP 5 (gen5)
+
+gen5 shares WHOOP 4's protocol almost entirely — same opcodes (except `HELLO`, which
+moves to `0x91`), same CRC32 payload check — wrapped in a different frame header
+(8 bytes + crc16-modbus instead of 4 bytes + crc8) and a different GATT service prefix
+(`fd4b…` instead of `6108…`). `BandProfile.gen5` selects it; everything else in this
+package takes a profile rather than hardcoding gen4's shape. See `gen5_records.dart` for
+the gen5-specific record layouts (v18/v20/v21/v26).
+
+## Oura ring
+
+`oura.dart` decodes the Oura ring's own BLE wire format — a different GATT service and
+byte layout from WHOOP entirely, reverse-engineered the same way the WHOOP records were:
+real captures, plausibility checks, no vendor docs.
+
+## Generic Bluetooth heart rate sensors
+
+`hrs.dart` decodes the Bluetooth SIG's standard Heart Rate Service (`0x2A37`
+characteristic under service `0x180D`) — the spec most chest straps and optical armbands
+already speak, independent of any single vendor. This is how OpenStrap works with a
+device it has never specifically reverse-engineered: if it speaks the SIG spec, this
+decoder already reads it.
 
 ## The one record that matters most
 
@@ -140,7 +186,7 @@ Pure Dart, no Flutter dependency:
 
 ```bash
 dart pub get
-dart test          # 71 tests, incl. the 2934-case TS-parity suite
+dart test          # the full suite, incl. the 2934-case TS-parity suite
 ```
 
 Run tests from the repo root — the parity fixture (`decode_parity_cases.json`) is
@@ -155,7 +201,9 @@ an honest "not sure." If you're touching `records.dart`'s multi-version decode c
 check `FirmwareAwareR24Decoder` first — chances are your case fits the existing fallback
 shape rather than needing a new one.
 
-Cross-checking against `_external/noop/`  `bWanShiTong/reverse-engineering-whoop-post/`  for facts/techniques is fine; copying its code is not.
+Cross-checking against other public reverse-engineering writeups for facts/techniques is
+fine — e.g. [bWanShiTong/reverse-engineering-whoop-post](https://github.com/bWanShiTong/reverse-engineering-whoop-post)
+— copying their code is not.
 
 ## Contributing
 

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -1416,6 +1416,24 @@ Decoded _decodeDataRecord(Uint8List inner,
   final recType = inner.length > 1 ? inner[1] : -1;
   // Compact realtime stream (small packet).
   if (inner.length < 64) {
+    // Revision-2 realtime HR carries off-body state + garment location that
+    // the legacy v1 decoder below cannot see, and misreads byte [9] of a v2
+    // body as a declared R-R count — try v2 first so those bytes never reach
+    // the v1 fallback.
+    if (recType == 2) {
+      final v2 = parseRealtimeHrV2(inner);
+      if (v2 != null) {
+        return Decoded('realtime_hr', {
+          'rec_type': recType,
+          'ts_epoch': v2.tsEpoch,
+          'hr': v2.hrBpm,
+          'hr_precise': v2.hrBpm.toDouble(),
+          'rr_ms': const <int>[],
+          'wearing': !v2.isOffBody,
+          'location_raw': v2.locationRaw,
+        });
+      }
+    }
     final hr = parseRealtimeHr(inner);
     if (hr != null) {
       return Decoded('realtime_hr', {
@@ -1432,16 +1450,21 @@ Decoded _decodeDataRecord(Uint8List inner,
   // Live R10 (HR + IMU) — surface HR for the live display.
   if (recType == Record.r10) {
     final r = parseR10Lite(inner);
-    if (r != null && r.hr > 0) {
+    if (r != null) {
       // rr_ms too: parseR10Lite already accepted these beats, and the short
       // realtime-HR branch above emits them — dropping them here silently
       // halved the beat supply of anything reading live R10 through
       // decodeFrame rather than live.dart.
+      //
+      // Emit even when hr == 0 — that's a real off-wrist reading (see
+      // live.dart's wristOn: hr > 0), not a failed decode. Falling through
+      // here used to collapse it into a bare 'data_record' with no wearing
+      // field at all, indistinguishable from an undecodable frame.
       return Decoded('realtime_hr', {
         'rec_type': recType,
         'hr': r.hr,
         'rr_ms': r.rrIntervalsMs,
-        'wearing': true,
+        'wearing': r.hr > 0,
       });
     }
   }

--- a/test/whoop_protocol_update_test.dart
+++ b/test/whoop_protocol_update_test.dart
@@ -580,5 +580,50 @@ void main() {
       expect(decoded.fields['hr'], 65);
       expect(decoded.fields['rr_ms'], isEmpty);
     });
+
+    // decodeFrame used to never route to parseRealtimeHrV2 at all — any short
+    // realtime packet fell straight to the v1 decoder, which reads a v2
+    // body's reserved byte [9] as an RR count and never surfaces off-body or
+    // garment location.
+    test(
+        'a revision-2 body routes to parseRealtimeHrV2 and surfaces off-body + location',
+        () {
+      final b = Uint8List(20);
+      final bd = b.buffer.asByteData();
+      b[0] = 0x28;
+      b[1] = 2; // revision 2
+      bd.setUint32(2, 1780840486, Endian.little); // ts
+      b[8] = 79; // hr
+      b[18] = 0; // off-body
+      b[19] = 2; // bicep
+
+      final decoded = decodeFrame(Frame(b, true, true));
+      expect(decoded.kind, 'realtime_hr');
+      expect(decoded.fields['ts_epoch'], 1780840486);
+      expect(decoded.fields['hr'], 79);
+      expect(decoded.fields['wearing'], isFalse);
+      expect(decoded.fields['location_raw'], 2);
+    });
+  });
+
+  group('live R10 dispatch', () {
+    // hr == 0 is a legitimate off-wrist reading (see live.dart's
+    // `wristOn: hr > 0`), not a failed decode. This used to fall through to a
+    // bare 'data_record' with no wearing field at all.
+    test('hr == 0 still emits realtime_hr with wearing:false, not silence',
+        () {
+      final b = Uint8List(64);
+      final bd = b.buffer.asByteData();
+      b[0] = 0x28;
+      b[1] = Record.r10;
+      bd.setUint32(3, 42, Endian.little); // counter
+      bd.setUint32(7, 1780840486, Endian.little); // ts
+      b[17] = 0; // hr == 0: off-wrist
+
+      final decoded = decodeFrame(Frame(b, true, true));
+      expect(decoded.kind, 'realtime_hr');
+      expect(decoded.fields['hr'], 0);
+      expect(decoded.fields['wearing'], isFalse);
+    });
   });
 }


### PR DESCRIPTION
couple things from an audit pass:

- decodeFrame never actually dispatched to parseRealtimeHrV2, so a real v2 realtime HR body (off-body state + garment location) always fell through to the legacy v1 decoder instead, which reads the v2 body's reserved byte[9] as an RR count. wired it in - v2 gets tried first when the rec byte is 2.
- r10 live dispatch only emitted realtime_hr when hr > 0, so a legit off-wrist reading (hr==0) produced no wearing signal at all through decodeFrame, same shape as an undecodable frame. now it always emits, with wearing: hr > 0.
- readme was stale in a few spots: described the package as WHOOP4-only when it's already got gen5/Oura/generic-BLE-HR support shipped, claimed a "71 tests" count that's actually 434 now, and pointed at an `_external/noop/` path that doesn't exist in this repo. cleaned all that up and added a short "part of OpenStrap" section since the readme had no pointer to analytics/edge at all.

added two decodeFrame tests covering both bugs. full suite green (434 tests), dart analyze clean.

## Summary by Sourcery

Correct realtime heart-rate frame dispatch and zero-heart-rate handling, and refresh the package documentation.

Bug Fixes:
- Dispatch revision-2 realtime heart-rate frames correctly so off-body state and garment location are preserved.
- Emit R10 realtime heart-rate records for valid zero-heart-rate readings with the correct wearing status.

Documentation:
- Update the README to document supported device families, OpenStrap project components, and current testing and reference information.

Tests:
- Add decodeFrame coverage for revision-2 realtime heart-rate dispatch and zero-heart-rate R10 readings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for decoding compact revision-2 real-time heart-rate records.
  - Exposes garment location and whether the sensor is being worn.
  - Preserves heart-rate records with zero BPM and identifies them as not being worn.

- **Documentation**
  - Expanded guidance for WHOOP 4/5, Oura, and generic Bluetooth heart-rate sensors.
  - Added architecture, decoder, and contribution documentation.

- **Tests**
  - Added coverage for revision-2 packets, off-body states, garment location, and zero-heart-rate records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->